### PR TITLE
Add CLI tool for WikiWho algorithm with compression support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +129,25 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cast"
@@ -251,6 +276,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,10 +374,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
+]
 
 [[package]]
 name = "getrandom"
@@ -519,6 +572,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -902,6 +965,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1097,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unindent"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,9 +1211,12 @@ dependencies = [
  "aho-corasick",
  "bincode",
  "blake3",
+ "bzip2",
  "chrono",
  "compact_str",
  "criterion",
+ "flate2",
+ "getopts",
  "hex",
  "imara-diff",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,11 @@ repository = "https://github.com/Schuwi/wikiwho_rs"
 description = "Fast Rust reimplementation of the WikiWho algorithm for fine-grained authorship attribution on large datasets. Optimized for easy integration in multi-threaded applications."
 exclude = [ "*.xml", "*.xml.zst" ]
 
+[[bin]]
+name = "wikiwho-cli"
+path = "src/bin/wikiwho-cli.rs"
+required-features = ["cli"]
+
 [[bench]]
 name = "bench_utils"
 harness = false
@@ -23,7 +28,8 @@ default = [ ]
 strict = []
 optimized-str = []
 python-diff = [ "dep:pyo3" ]
-serde = [ "dep:serde", "chrono/serde", "compact_str/serde" ]
+serde = [ "dep:serde", "dep:serde_json", "chrono/serde", "compact_str/serde" ]
+cli = [ "serde", "dep:getopts", "dep:bzip2", "dep:flate2", "dep:zstd" ]
 
 [dependencies]
 aho-corasick = "1.1.3"
@@ -38,6 +44,11 @@ rand = "0.8.5"
 regex = "1.10.6"
 rustc-hash = "2.0.0"
 serde = { version = "1.0.213", optional = true, features = ["derive"] }
+serde_json = { version = "1.0.132", optional = true }
+bzip2 = { version = "0.5", optional = true }
+flate2 = { version = "1", optional = true }
+getopts = { version = "0.2", optional = true }
+zstd = { version = "0.13.2", optional = true }
 string-interner = "0.17.0"
 thiserror = "1.0.63"
 tracing = "0.1.40"

--- a/src/bin/wikiwho-cli.rs
+++ b/src/bin/wikiwho-cli.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
+use std::collections::BTreeMap;
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::process::ExitCode;
+use std::sync::Mutex;
 
 use wikiwho::algorithm::PageAnalysis;
-use wikiwho::dump_parser::{Contributor, DumpParser};
+use wikiwho::dump_parser::{Contributor, DumpParser, Page};
 use wikiwho::utils::iterate_revision_tokens;
 
 fn format_editor(contributor: &Contributor) -> String {
@@ -34,6 +36,7 @@ Options:
   -o, --output PATH       Output file (omit or \"-\" for stdout)
                           Compression auto-detected from extension (.bz2, .zst, .gz)
   -f, --format FORMAT     Output format: jsonl (default), json, raw
+  -j, --jobs N            Number of worker threads (default: number of CPUs)
   -n, --namespace NS      Only process pages in this namespace (repeatable)
   -q, --quiet             Suppress progress messages on stderr
   -h, --help              Show this help message"
@@ -54,6 +57,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let mut opts = getopts::Options::new();
     opts.optopt("o", "output", "Output file (\"-\" or omit for stdout)", "PATH");
     opts.optopt("f", "format", "Output format: jsonl (default), json, raw", "FORMAT");
+    opts.optopt("j", "jobs", "Number of worker threads", "N");
     opts.optmulti("n", "namespace", "Only process pages in this namespace", "NS");
     opts.optflag("q", "quiet", "Suppress progress messages on stderr");
     opts.optflag("h", "help", "Show help");
@@ -73,6 +77,17 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         Some(other) => return Err(format!("unknown format: {other}").into()),
     };
 
+    let num_threads: usize = match matches.opt_str("j") {
+        Some(s) => {
+            let n = s.parse::<usize>().map_err(|e| format!("invalid -j value: {e}"))?;
+            if n == 0 {
+                return Err("--jobs must be at least 1".into());
+            }
+            n
+        }
+        None => std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1),
+    };
+
     let namespace_filter: Vec<i32> = matches
         .opt_strs("n")
         .iter()
@@ -86,8 +101,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let output_path = matches.opt_str("o");
 
     // Set up input reader with auto-decompression
-    let reader: Box<dyn BufRead> = match input_path {
-        None | Some("-") => Box::new(BufReader::new(io::stdin().lock())),
+    let reader: Box<dyn BufRead + Send> = match input_path {
+        None | Some("-") => Box::new(BufReader::new(io::stdin())),
         Some(path) => {
             let file = std::fs::File::open(path)
                 .map_err(|e| format!("cannot open input '{path}': {e}"))?;
@@ -132,11 +147,16 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    process(reader, writer, format, &namespace_filter, quiet)
+    if num_threads == 1 {
+        process_single(reader, writer, format, &namespace_filter, quiet)
+    } else {
+        process_parallel(reader, writer, format, &namespace_filter, quiet, num_threads)
+    }
 }
 
-fn process(
-    reader: Box<dyn BufRead>,
+/// Single-threaded processing (original path, used when -j 1).
+fn process_single(
+    reader: Box<dyn BufRead + Send>,
     mut writer: Box<dyn Write>,
     format: Format,
     namespace_filter: &[i32],
@@ -170,24 +190,7 @@ fn process(
             }
         };
 
-        match format {
-            Format::Jsonl => {
-                let obj = build_page_json(&page, &analysis);
-                serde_json::to_writer(&mut writer, &obj)?;
-                writeln!(writer)?;
-            }
-            Format::Json => {
-                if page_count > 0 {
-                    write!(writer, ",")?;
-                }
-                let obj = build_page_json(&page, &analysis);
-                serde_json::to_writer(&mut writer, &obj)?;
-            }
-            Format::Raw => {
-                serde_json::to_writer(&mut writer, &analysis)?;
-                writeln!(writer)?;
-            }
-        }
+        write_page_result(&mut writer, &page, &analysis, format, page_count)?;
 
         page_count += 1;
         if !quiet && page_count % 100 == 0 {
@@ -208,8 +211,174 @@ fn process(
     Ok(())
 }
 
+/// Result from a worker thread: either a successful analysis or a skipped page.
+enum AnalysisResult {
+    Ok(Page, PageAnalysis),
+    Skipped(String, String), // (title, error message)
+}
+
+/// Multi-threaded processing pipeline:
+///   parser (1 thread) -> workers (N threads) -> writer (main thread, reordering)
+fn process_parallel(
+    reader: Box<dyn BufRead + Send>,
+    mut writer: Box<dyn Write>,
+    format: Format,
+    namespace_filter: &[i32],
+    quiet: bool,
+    num_threads: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut parser = DumpParser::new(reader).map_err(|e| format!("failed to initialize parser: {e:?}"))?;
+
+    if !quiet {
+        let info = parser.site_info();
+        eprintln!("Database: {}", info.dbname);
+        eprintln!("Using {} worker threads", num_threads);
+    }
+
+    // Bounded channel: parser -> workers (back-pressure to avoid unbounded memory growth)
+    let (work_tx, work_rx) = std::sync::mpsc::sync_channel::<(u64, Page)>(num_threads * 2);
+    let work_rx = Mutex::new(work_rx);
+
+    // Unbounded channel: workers -> writer (results arrive out of order, reordered before writing)
+    let (result_tx, result_rx) = std::sync::mpsc::channel::<(u64, AnalysisResult)>();
+
+    // Track errors from the parser thread
+    let parse_error: Mutex<Option<String>> = Mutex::new(None);
+
+    std::thread::scope(|s| {
+        // Spawn N worker threads that pull pages and analyze them
+        for _ in 0..num_threads {
+            let work_rx = &work_rx;
+            let result_tx = result_tx.clone();
+            s.spawn(move || {
+                loop {
+                    let item = work_rx.lock().unwrap().recv();
+                    let (seq, page) = match item {
+                        Ok(v) => v,
+                        Err(_) => break, // channel closed, no more work
+                    };
+                    let result = match PageAnalysis::analyse_page(&page.revisions) {
+                        Ok(analysis) => AnalysisResult::Ok(page, analysis),
+                        Err(e) => AnalysisResult::Skipped(page.title.to_string(), e.to_string()),
+                    };
+                    // If the writer has dropped, stop
+                    if result_tx.send((seq, result)).is_err() {
+                        break;
+                    }
+                }
+            });
+        }
+
+        // Drop the original result_tx so that result_rx closes once all workers finish
+        drop(result_tx);
+
+        // Parser thread: reads pages sequentially, applies namespace filter, sends to workers
+        let parse_error_ref = &parse_error;
+        s.spawn(move || {
+            let mut seq = 0u64;
+            loop {
+                match parser.parse_page() {
+                    Ok(Some(page)) => {
+                        if !namespace_filter.is_empty() && !namespace_filter.contains(&page.namespace) {
+                            continue;
+                        }
+                        if work_tx.send((seq, page)).is_err() {
+                            break; // workers gone
+                        }
+                        seq += 1;
+                    }
+                    Ok(None) => break, // end of stream
+                    Err(e) => {
+                        *parse_error_ref.lock().unwrap() = Some(format!("XML parse error: {e:?}"));
+                        break;
+                    }
+                }
+            }
+            // work_tx is dropped here, signaling workers to finish
+        });
+
+        // Main thread: collect results, reorder, and write
+        if format == Format::Json {
+            write!(writer, "[").unwrap();
+        }
+
+        let mut next_seq: u64 = 0;
+        let mut page_count: u64 = 0;
+        let mut reorder_buf: BTreeMap<u64, AnalysisResult> = BTreeMap::new();
+
+        for (seq, result) in &result_rx {
+            reorder_buf.insert(seq, result);
+
+            // Flush all consecutive ready results
+            while let Some(result) = reorder_buf.remove(&next_seq) {
+                next_seq += 1;
+                match result {
+                    AnalysisResult::Skipped(title, err) => {
+                        if !quiet {
+                            eprintln!("Warning: skipping '{title}': {err}");
+                        }
+                    }
+                    AnalysisResult::Ok(page, analysis) => {
+                        write_page_result(&mut writer, &page, &analysis, format, page_count)
+                            .unwrap();
+                        page_count += 1;
+                        if !quiet && page_count % 100 == 0 {
+                            eprintln!("Processed {page_count} pages (latest: {})", page.title);
+                        }
+                    }
+                }
+            }
+        }
+
+        if format == Format::Json {
+            writeln!(writer, "]").unwrap();
+        }
+
+        writer.flush().unwrap();
+
+        if !quiet {
+            eprintln!("Done. Processed {page_count} pages.");
+        }
+    });
+
+    // Check if the parser hit an error
+    if let Some(err) = parse_error.into_inner().unwrap() {
+        return Err(err.into());
+    }
+
+    Ok(())
+}
+
+fn write_page_result(
+    writer: &mut Box<dyn Write>,
+    page: &Page,
+    analysis: &PageAnalysis,
+    format: Format,
+    page_count: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match format {
+        Format::Jsonl => {
+            let obj = build_page_json(page, analysis);
+            serde_json::to_writer(&mut *writer, &obj)?;
+            writeln!(writer)?;
+        }
+        Format::Json => {
+            if page_count > 0 {
+                write!(writer, ",")?;
+            }
+            let obj = build_page_json(page, analysis);
+            serde_json::to_writer(&mut *writer, &obj)?;
+        }
+        Format::Raw => {
+            serde_json::to_writer(&mut *writer, analysis)?;
+            writeln!(writer)?;
+        }
+    }
+    Ok(())
+}
+
 fn build_page_json(
-    page: &wikiwho::dump_parser::Page,
+    page: &Page,
     analysis: &PageAnalysis,
 ) -> serde_json::Value {
     let revisions: Vec<serde_json::Value> = analysis

--- a/src/bin/wikiwho-cli.rs
+++ b/src/bin/wikiwho-cli.rs
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: MPL-2.0
+use std::io::{self, BufRead, BufReader, BufWriter, Write};
+use std::process::ExitCode;
+
+use wikiwho::algorithm::PageAnalysis;
+use wikiwho::dump_parser::{Contributor, DumpParser};
+use wikiwho::utils::iterate_revision_tokens;
+
+fn format_editor(contributor: &Contributor) -> String {
+    match contributor.id {
+        Some(id) if id != 0 => id.to_string(),
+        _ => format!("0|{}", contributor.username),
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Format {
+    Jsonl,
+    Json,
+    Raw,
+}
+
+fn print_usage(program: &str) {
+    eprintln!(
+        "Usage: {program} [OPTIONS] [INPUT]
+
+Runs the WikiWho authorship attribution algorithm on a MediaWiki XML dump.
+
+Arguments:
+  INPUT                   Input XML dump file (omit or \"-\" for stdin)
+                          Compression auto-detected from extension (.bz2, .zst, .gz)
+
+Options:
+  -o, --output PATH       Output file (omit or \"-\" for stdout)
+                          Compression auto-detected from extension (.bz2, .zst, .gz)
+  -f, --format FORMAT     Output format: jsonl (default), json, raw
+  -n, --namespace NS      Only process pages in this namespace (repeatable)
+  -q, --quiet             Suppress progress messages on stderr
+  -h, --help              Show this help message"
+    );
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let mut opts = getopts::Options::new();
+    opts.optopt("o", "output", "Output file (\"-\" or omit for stdout)", "PATH");
+    opts.optopt("f", "format", "Output format: jsonl (default), json, raw", "FORMAT");
+    opts.optmulti("n", "namespace", "Only process pages in this namespace", "NS");
+    opts.optflag("q", "quiet", "Suppress progress messages on stderr");
+    opts.optflag("h", "help", "Show help");
+
+    let args: Vec<String> = std::env::args().collect();
+    let matches = opts.parse(&args[1..]).map_err(|e| e.to_string())?;
+
+    if matches.opt_present("h") {
+        print_usage(&args[0]);
+        return Ok(());
+    }
+
+    let format = match matches.opt_str("f").as_deref() {
+        None | Some("jsonl") => Format::Jsonl,
+        Some("json") => Format::Json,
+        Some("raw") => Format::Raw,
+        Some(other) => return Err(format!("unknown format: {other}").into()),
+    };
+
+    let namespace_filter: Vec<i32> = matches
+        .opt_strs("n")
+        .iter()
+        .map(|s| s.parse::<i32>())
+        .collect::<Result<_, _>>()
+        .map_err(|e| format!("invalid namespace: {e}"))?;
+
+    let quiet = matches.opt_present("q");
+
+    let input_path = matches.free.first().map(|s| s.as_str());
+    let output_path = matches.opt_str("o");
+
+    // Set up input reader with auto-decompression
+    let reader: Box<dyn BufRead> = match input_path {
+        None | Some("-") => Box::new(BufReader::new(io::stdin().lock())),
+        Some(path) => {
+            let file = std::fs::File::open(path)
+                .map_err(|e| format!("cannot open input '{path}': {e}"))?;
+            if path.ends_with(".bz2") {
+                Box::new(BufReader::new(bzip2::read::BzDecoder::new(file)))
+            } else if path.ends_with(".zst") || path.ends_with(".zstd") {
+                Box::new(BufReader::new(
+                    zstd::Decoder::new(file).map_err(|e| format!("zstd init: {e}"))?,
+                ))
+            } else if path.ends_with(".gz") {
+                Box::new(BufReader::new(flate2::read::GzDecoder::new(file)))
+            } else {
+                Box::new(BufReader::new(file))
+            }
+        }
+    };
+
+    // Set up output writer with auto-compression
+    let writer: Box<dyn Write> = match output_path.as_deref() {
+        None | Some("-") => Box::new(BufWriter::new(io::stdout().lock())),
+        Some(path) => {
+            let file = std::fs::File::create(path)
+                .map_err(|e| format!("cannot create output '{path}': {e}"))?;
+            if path.ends_with(".bz2") {
+                Box::new(BufWriter::new(bzip2::write::BzEncoder::new(
+                    file,
+                    bzip2::Compression::default(),
+                )))
+            } else if path.ends_with(".zst") || path.ends_with(".zstd") {
+                Box::new(BufWriter::new(
+                    zstd::Encoder::new(file, 3)
+                        .map_err(|e| format!("zstd init: {e}"))?,
+                ))
+            } else if path.ends_with(".gz") {
+                Box::new(BufWriter::new(flate2::write::GzEncoder::new(
+                    file,
+                    flate2::Compression::default(),
+                )))
+            } else {
+                Box::new(BufWriter::new(file))
+            }
+        }
+    };
+
+    process(reader, writer, format, &namespace_filter, quiet)
+}
+
+fn process(
+    reader: Box<dyn BufRead>,
+    mut writer: Box<dyn Write>,
+    format: Format,
+    namespace_filter: &[i32],
+    quiet: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut parser = DumpParser::new(reader).map_err(|e| format!("failed to initialize parser: {e:?}"))?;
+
+    if !quiet {
+        let info = parser.site_info();
+        eprintln!("Database: {}", info.dbname);
+    }
+
+    let mut page_count: u64 = 0;
+
+    if format == Format::Json {
+        write!(writer, "[")?;
+    }
+
+    while let Some(page) = parser.parse_page().map_err(|e| format!("XML parse error: {e:?}"))? {
+        if !namespace_filter.is_empty() && !namespace_filter.contains(&page.namespace) {
+            continue;
+        }
+
+        let analysis = match PageAnalysis::analyse_page(&page.revisions) {
+            Ok(a) => a,
+            Err(e) => {
+                if !quiet {
+                    eprintln!("Warning: skipping '{}': {e}", page.title);
+                }
+                continue;
+            }
+        };
+
+        match format {
+            Format::Jsonl => {
+                let obj = build_page_json(&page, &analysis);
+                serde_json::to_writer(&mut writer, &obj)?;
+                writeln!(writer)?;
+            }
+            Format::Json => {
+                if page_count > 0 {
+                    write!(writer, ",")?;
+                }
+                let obj = build_page_json(&page, &analysis);
+                serde_json::to_writer(&mut writer, &obj)?;
+            }
+            Format::Raw => {
+                serde_json::to_writer(&mut writer, &analysis)?;
+                writeln!(writer)?;
+            }
+        }
+
+        page_count += 1;
+        if !quiet && page_count % 100 == 0 {
+            eprintln!("Processed {page_count} pages (latest: {})", page.title);
+        }
+    }
+
+    if format == Format::Json {
+        writeln!(writer, "]")?;
+    }
+
+    writer.flush()?;
+
+    if !quiet {
+        eprintln!("Done. Processed {page_count} pages.");
+    }
+
+    Ok(())
+}
+
+fn build_page_json(
+    page: &wikiwho::dump_parser::Page,
+    analysis: &PageAnalysis,
+) -> serde_json::Value {
+    let revisions: Vec<serde_json::Value> = analysis
+        .ordered_revisions
+        .iter()
+        .map(|rev_ptr| {
+            serde_json::json!({
+                "id": rev_ptr.xml_revision.id,
+                "timestamp": rev_ptr.xml_revision.timestamp.to_rfc3339(),
+                "editor": format_editor(&rev_ptr.xml_revision.contributor),
+            })
+        })
+        .collect();
+
+    // Build all_tokens from the last (current) revision's content
+    let last_rev = &analysis.current_revision;
+    let tokens: Vec<serde_json::Value> = iterate_revision_tokens(analysis, last_rev)
+        .map(|word_ptr| {
+            let word_analysis = &analysis[word_ptr];
+            serde_json::json!({
+                "token_id": word_ptr.unique_id(),
+                "str": &*word_ptr.value,
+                "o_rev_id": word_analysis.origin_revision.xml_revision.id,
+                "editor": format_editor(&word_analysis.origin_revision.xml_revision.contributor),
+                "in": word_analysis.inbound.iter().map(|r| r.xml_revision.id).collect::<Vec<_>>(),
+                "out": word_analysis.outbound.iter().map(|r| r.xml_revision.id).collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+
+    serde_json::json!({
+        "article_title": &*page.title,
+        "namespace": page.namespace,
+        "revisions": revisions,
+        "spam_ids": &analysis.spam_ids,
+        "all_tokens": tokens,
+    })
+}

--- a/src/bin/wikiwho-cli.rs
+++ b/src/bin/wikiwho-cli.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::process::ExitCode;
 use std::sync::Mutex;
 
 use wikiwho::algorithm::PageAnalysis;
-use wikiwho::dump_parser::{Contributor, DumpParser, Page};
+use wikiwho::dump_parser::{Contributor, DumpParser, Page, Revision};
 use wikiwho::utils::iterate_revision_tokens;
 
 fn format_editor(contributor: &Contributor) -> String {
@@ -38,6 +38,7 @@ Options:
   -f, --format FORMAT     Output format: jsonl (default), json, raw
   -j, --jobs N            Number of worker threads (default: number of CPUs)
   -n, --namespace NS      Only process pages in this namespace (repeatable)
+  -N, --pages N           Only process the first N pages
   -q, --quiet             Suppress progress messages on stderr
   -h, --help              Show this help message"
     );
@@ -55,10 +56,26 @@ fn main() -> ExitCode {
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
     let mut opts = getopts::Options::new();
-    opts.optopt("o", "output", "Output file (\"-\" or omit for stdout)", "PATH");
-    opts.optopt("f", "format", "Output format: jsonl (default), json, raw", "FORMAT");
+    opts.optopt(
+        "o",
+        "output",
+        "Output file (\"-\" or omit for stdout)",
+        "PATH",
+    );
+    opts.optopt(
+        "f",
+        "format",
+        "Output format: jsonl (default), json, raw",
+        "FORMAT",
+    );
     opts.optopt("j", "jobs", "Number of worker threads", "N");
-    opts.optmulti("n", "namespace", "Only process pages in this namespace", "NS");
+    opts.optmulti(
+        "n",
+        "namespace",
+        "Only process pages in this namespace",
+        "NS",
+    );
+    opts.optopt("N", "limit", "Limit the number of pages to process", "N");
     opts.optflag("q", "quiet", "Suppress progress messages on stderr");
     opts.optflag("h", "help", "Show help");
 
@@ -79,13 +96,17 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let num_threads: usize = match matches.opt_str("j") {
         Some(s) => {
-            let n = s.parse::<usize>().map_err(|e| format!("invalid -j value: {e}"))?;
+            let n = s
+                .parse::<usize>()
+                .map_err(|e| format!("invalid -j value: {e}"))?;
             if n == 0 {
                 return Err("--jobs must be at least 1".into());
             }
             n
         }
-        None => std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1),
+        None => std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1),
     };
 
     let namespace_filter: Vec<i32> = matches
@@ -94,6 +115,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         .map(|s| s.parse::<i32>())
         .collect::<Result<_, _>>()
         .map_err(|e| format!("invalid namespace: {e}"))?;
+
+    let limit_pages: Option<u64> = matches.opt_get("N")?;
 
     let quiet = matches.opt_present("q");
 
@@ -133,8 +156,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 )))
             } else if path.ends_with(".zst") || path.ends_with(".zstd") {
                 Box::new(BufWriter::new(
-                    zstd::Encoder::new(file, 3)
-                        .map_err(|e| format!("zstd init: {e}"))?,
+                    zstd::Encoder::new(file, 3).map_err(|e| format!("zstd init: {e}"))?,
                 ))
             } else if path.ends_with(".gz") {
                 Box::new(BufWriter::new(flate2::write::GzEncoder::new(
@@ -148,9 +170,24 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     if num_threads == 1 {
-        process_single(reader, writer, format, &namespace_filter, quiet)
+        process_single(
+            reader,
+            writer,
+            format,
+            &namespace_filter,
+            quiet,
+            limit_pages,
+        )
     } else {
-        process_parallel(reader, writer, format, &namespace_filter, quiet, num_threads)
+        process_parallel(
+            reader,
+            writer,
+            format,
+            &namespace_filter,
+            quiet,
+            limit_pages,
+            num_threads,
+        )
     }
 }
 
@@ -161,8 +198,10 @@ fn process_single(
     format: Format,
     namespace_filter: &[i32],
     quiet: bool,
+    page_limit: Option<u64>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut parser = DumpParser::new(reader).map_err(|e| format!("failed to initialize parser: {e:?}"))?;
+    let mut parser =
+        DumpParser::new(reader).map_err(|e| format!("failed to initialize parser: {e:?}"))?;
 
     if !quiet {
         let info = parser.site_info();
@@ -175,9 +214,16 @@ fn process_single(
         write!(writer, "[")?;
     }
 
-    while let Some(page) = parser.parse_page().map_err(|e| format!("XML parse error: {e:?}"))? {
+    while let Some(page) = parser
+        .parse_page()
+        .map_err(|e| format!("XML parse error: {e:?}"))?
+    {
         if !namespace_filter.is_empty() && !namespace_filter.contains(&page.namespace) {
             continue;
+        }
+
+        if page_limit.map(|n| page_count >= n).unwrap_or(false) {
+            break; // page limit reached
         }
 
         let analysis = match PageAnalysis::analyse_page(&page.revisions) {
@@ -190,11 +236,12 @@ fn process_single(
             }
         };
 
-        write_page_result(&mut writer, &page, &analysis, format, page_count)?;
+        let page_title = page.title.clone();
+        write_page_result(&mut writer, page, &analysis, format, page_count)?;
 
         page_count += 1;
         if !quiet && page_count % 100 == 0 {
-            eprintln!("Processed {page_count} pages (latest: {})", page.title);
+            eprintln!("Processed {page_count} pages (latest: {})", page_title);
         }
     }
 
@@ -225,9 +272,11 @@ fn process_parallel(
     format: Format,
     namespace_filter: &[i32],
     quiet: bool,
+    page_limit: Option<u64>,
     num_threads: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut parser = DumpParser::new(reader).map_err(|e| format!("failed to initialize parser: {e:?}"))?;
+    let mut parser =
+        DumpParser::new(reader).map_err(|e| format!("failed to initialize parser: {e:?}"))?;
 
     if !quiet {
         let info = parser.site_info();
@@ -279,8 +328,13 @@ fn process_parallel(
             loop {
                 match parser.parse_page() {
                     Ok(Some(page)) => {
-                        if !namespace_filter.is_empty() && !namespace_filter.contains(&page.namespace) {
+                        if !namespace_filter.is_empty()
+                            && !namespace_filter.contains(&page.namespace)
+                        {
                             continue;
+                        }
+                        if page_limit.map(|n| seq >= n).unwrap_or(false) {
+                            break; // page limit reached
                         }
                         if work_tx.send((seq, page)).is_err() {
                             break; // workers gone
@@ -319,12 +373,13 @@ fn process_parallel(
                         }
                     }
                     AnalysisResult::Ok(page, analysis) => {
-                        write_page_result(&mut writer, &page, &analysis, format, page_count)
-                            .unwrap();
+                        let page_title = page.title.clone();
+                        write_page_result(&mut writer, page, &analysis, format, page_count).unwrap();
                         page_count += 1;
                         if !quiet && page_count % 100 == 0 {
-                            eprintln!("Processed {page_count} pages (latest: {})", page.title);
+                            eprintln!("Processed {page_count} pages (latest: {})", page_title);
                         }
+                        drop(analysis);
                     }
                 }
             }
@@ -351,7 +406,7 @@ fn process_parallel(
 
 fn write_page_result(
     writer: &mut Box<dyn Write>,
-    page: &Page,
+    page: Page,
     analysis: &PageAnalysis,
     format: Format,
     page_count: u64,
@@ -377,18 +432,22 @@ fn write_page_result(
     Ok(())
 }
 
-fn build_page_json(
-    page: &Page,
-    analysis: &PageAnalysis,
-) -> serde_json::Value {
+fn build_page_json(page: Page, analysis: &PageAnalysis) -> serde_json::Value {
+    let revisions_by_id: HashMap<i32, Revision> = page
+        .revisions
+        .into_iter()
+        .map(|rev| (rev.id, rev))
+        .collect();
+
     let revisions: Vec<serde_json::Value> = analysis
         .ordered_revisions
         .iter()
         .map(|rev_ptr| {
+            let xml_revision = &revisions_by_id[&rev_ptr.id];
             serde_json::json!({
-                "id": rev_ptr.xml_revision.id,
-                "timestamp": rev_ptr.xml_revision.timestamp.to_rfc3339(),
-                "editor": format_editor(&rev_ptr.xml_revision.contributor),
+                "id": xml_revision.id,
+                "timestamp": xml_revision.timestamp.to_rfc3339(),
+                "editor": format_editor(&xml_revision.contributor),
             })
         })
         .collect();
@@ -398,13 +457,14 @@ fn build_page_json(
     let tokens: Vec<serde_json::Value> = iterate_revision_tokens(analysis, last_rev)
         .map(|word_ptr| {
             let word_analysis = &analysis[word_ptr];
+            let xml_origin_revision = &revisions_by_id[&word_analysis.origin_revision.id];
             serde_json::json!({
                 "token_id": word_ptr.unique_id(),
                 "str": &*word_ptr.value,
-                "o_rev_id": word_analysis.origin_revision.xml_revision.id,
-                "editor": format_editor(&word_analysis.origin_revision.xml_revision.contributor),
-                "in": word_analysis.inbound.iter().map(|r| r.xml_revision.id).collect::<Vec<_>>(),
-                "out": word_analysis.outbound.iter().map(|r| r.xml_revision.id).collect::<Vec<_>>(),
+                "o_rev_id": xml_origin_revision.id,
+                "editor": format_editor(&xml_origin_revision.contributor),
+                "in": word_analysis.inbound.iter().map(|r| r.id).collect::<Vec<_>>(),
+                "out": word_analysis.outbound.iter().map(|r| r.id).collect::<Vec<_>>(),
             })
         })
         .collect();


### PR DESCRIPTION
## Summary
This PR adds a new command-line interface (CLI) binary to the wikiwho crate, enabling users to run the WikiWho authorship attribution algorithm directly on MediaWiki XML dumps from the command line.

## Key Changes
- **New CLI binary** (`src/bin/wikiwho-cli.rs`): A complete command-line tool that:
  - Parses MediaWiki XML dumps with automatic compression detection (.bz2, .zst, .gz)
  - Runs the WikiWho algorithm on each page
  - Outputs results in multiple formats (JSONL, JSON, or raw analysis format)
  - Supports namespace filtering to process only specific page namespaces
  - Provides progress reporting and error handling with optional quiet mode

- **Feature configuration** (`Cargo.toml`):
  - Added new `cli` feature flag that depends on `serde`, `getopts`, `bzip2`, `flate2`, and `zstd`
  - Updated `serde` feature to include `serde_json` dependency
  - Made compression libraries optional dependencies only required for CLI usage

## Notable Implementation Details
- **Auto-decompression**: Input files are automatically decompressed based on file extension
- **Auto-compression**: Output files are automatically compressed based on file extension
- **Multiple output formats**: 
  - JSONL (default): One JSON object per line for streaming
  - JSON: Single JSON array containing all results
  - Raw: Direct serialization of PageAnalysis objects
- **Detailed token attribution**: Output includes per-token authorship information with origin revision, editor, and inbound/outbound revision tracking
- **Progress tracking**: Periodic status updates on stderr (every 100 pages) with latest processed page title
- **Flexible I/O**: Supports stdin/stdout via "-" or file paths with automatic format detection

https://claude.ai/code/session_01E1jBBMCgD1oe5omZZCBmWT