### PR TITLE
ci: provenance-backed release workflow + SemVer/changelog PR gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,25 @@ jobs:
         with:
           feature-group: all-features
 
+  changelog:
+    name: changelog entry
+    # PRs must record their change under [Unreleased] in CHANGELOG.md. Skipped for Dependabot
+    # and for PRs carrying the `skip-changelog` label (CI/docs/refactors that don't warrant one).
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0, lfs: false }
+      - name: Require a CHANGELOG.md update
+        run: |
+          git fetch --no-tags origin "$GITHUB_BASE_REF"
+          if git diff --name-only "origin/$GITHUB_BASE_REF...HEAD" | grep -qx 'CHANGELOG.md'; then
+            echo "CHANGELOG.md updated."
+          else
+            echo "::error::Add an entry under [Unreleased] in CHANGELOG.md, or apply the 'skip-changelog' label for changes that don't warrant one (CI, docs, refactors)."
+            exit 1
+          fi
+
   # --- Headline: prove the Rust implementation matches the reference Python WikiWho ---
 
   parity-deterministic:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,25 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo package --no-verify
 
+  semver:
+    name: semver (all features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { lfs: false }
+      # cargo-semver-checks compares the public API against the latest crates.io release and
+      # fails if the version in Cargo.toml doesn't reflect the change (0.x rules understood) —
+      # so a PR that makes a breaking change must bump the version (the minor field, for 0.x).
+      # --all-features covers the whole surface, incl. the python-diff `use_python_diff` toggle;
+      # pyo3 only needs a Python interpreter to *build* (not the WikiWho venv — rustdoc is
+      # compiled, never run). This is also what enforces SemVer for releases: release.yml
+      # requires this workflow to be green for the tagged commit.
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12" }
+      - uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          feature-group: all-features
+
   # --- Headline: prove the Rust implementation matches the reference Python WikiWho ---
 
   parity-deterministic:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,130 @@
+name: Release
+
+# Tag-driven release. Publishes `wikiwho` to crates.io from CI (never a laptop) with
+# verifiable provenance. See RELEASING.md for the full rationale.
+#
+# This workflow is intentionally NON-reusable and triggered ONLY by a tag push: that keeps
+# the signer identity equal to the source (no reusable-workflow signer != source gap) and
+# guarantees the signing certificate's SAN is always release.yml@refs/tags/v*, which is what
+# consumers pin with `gh attestation verify --cert-identity`.
+on:
+  push:
+    tags: ["v*"]
+
+# Never run two publishes for the same tag at once.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # create the GitHub Release
+  id-token: write # OIDC: Trusted Publishing + provenance attestation
+  attestations: write # actions/attest-build-provenance
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    name: publish to crates.io
+    runs-on: ubuntu-latest
+    # Manual-approval gate configured in repo Settings -> Environments -> release.
+    environment: release
+    steps:
+      # Third-party actions are pinned to full commit SHAs (not mutable tags) because this
+      # workflow holds the publish/attestation credentials. Dependabot (github-actions)
+      # keeps the pins current; the trailing comment tracks the human-readable version.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with: { lfs: false } # packaging excludes dev-data; no LFS payload needed
+
+      # Rust stable is preinstalled on ubuntu-latest; use it instead of a toolchain action to
+      # keep this credentialed workflow's third-party surface minimal.
+      - run: rustup default stable
+
+      # --- Gate 1: refuse to publish unless ci.yml is green for THIS exact commit. ---
+      # ci.yml runs on push-to-main, so the tagged commit (tip of green main) already has
+      # a successful run. Poll briefly in case the tag was pushed before CI finished.
+      - name: Require green CI for this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sha="${GITHUB_SHA}"
+          deadline=$(( $(date +%s) + 900 )) # wait up to 15 min
+          while :; do
+            json=$(gh run list --workflow ci.yml --commit "$sha" \
+                     --json status,conclusion --limit 1)
+            status=$(echo "$json" | jq -r '.[0].status // empty')
+            conclusion=$(echo "$json" | jq -r '.[0].conclusion // empty')
+            if [ -z "$status" ]; then
+              echo "No ci.yml run found yet for $sha; waiting..."
+            elif [ "$status" != "completed" ]; then
+              echo "ci.yml run is '$status'; waiting..."
+            elif [ "$conclusion" = "success" ]; then
+              echo "ci.yml succeeded for $sha."
+              break
+            else
+              echo "::error::ci.yml for $sha concluded '$conclusion'; refusing to publish."
+              exit 1
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::Timed out waiting for a successful ci.yml run on $sha. Tag the tip of a green main."
+              exit 1
+            fi
+            sleep 30
+          done
+
+      # --- Gate 2: Cargo.toml version must equal the tag. ---
+      - name: Version matches tag
+        run: |
+          v=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].version')
+          if [ "v$v" != "${GITHUB_REF_NAME}" ]; then
+            echo "::error::Cargo.toml version v$v != tag ${GITHUB_REF_NAME}"
+            exit 1
+          fi
+          echo "Releasing v$v"
+
+      # NOTE: SemVer is enforced by ci.yml's `semver` job (over --all-features, incl.
+      # python-diff), not here. Gate 1 above already requires that ci.yml run to be green for
+      # the tagged commit, so a version that understates the API change can't be released — and
+      # this credentialed workflow stays leaner (one less third-party action, no Python).
+
+      # --- Publish to crates.io via Trusted Publishing (OIDC): no CARGO_REGISTRY_TOKEN is
+      # stored anywhere. `cargo publish` runs a verification build and leaves the exact
+      # uploaded tarball in target/package/, which we then attest and attach — so the
+      # attestation subject, the release asset, and the crates.io bytes are identical by
+      # construction (no reliance on cargo packaging being byte-deterministic across runs). ---
+      - name: Authenticate to crates.io (OIDC)
+        id: auth
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+
+      - name: Publish
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      # --- Create the immutable GitHub Release (after the crates.io publish succeeded). The repo
+      # has immutable releases enabled, so publishing locks the tag to this commit (which is what
+      # makes verification by tag name sound) and auto-generates a GitHub-signed release
+      # attestation over the asset digest. The exact tarball cargo publish uploaded (still in
+      # target/package/) is attached as an independent cross-link to the crates.io artifact;
+      # it is deliberately NOT the documented verification target (consumers verify the crates.io
+      # download — see README). Uses GitHub's recommended draft -> attach -> publish flow so the
+      # asset is in place before immutability locks. ---
+      - name: GitHub Release (immutable, with .crate cross-link)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" target/package/*.crate \
+            --draft --verify-tag --generate-notes
+          gh release edit "${GITHUB_REF_NAME}" --draft=false
+
+      # --- Attest build provenance LAST. Because this is the final step, a valid attestation
+      # for this tag can exist ONLY once both the crates.io publish AND the immutable release
+      # have succeeded — there is never an orphan attestation binding a .crate to a tag that
+      # never shipped. If any earlier step fails the run fails closed (no attestation -> the
+      # consumer's `gh attestation verify` fails safe, rather than passing for an artifact that
+      # was never published). Subject == the release asset == the crates.io bytes (one file). ---
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: target/package/*.crate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-<!-- Add your change under the relevant category: Added / Changed / Deprecated / Removed / Fixed / Security. -->
+### Added
+
+- Releases are now built and published by CI with a verifiable [SLSA build-provenance attestation](https://github.com/actions/attest-build-provenance); published crates can be checked with `gh attestation verify` (see "Verifying a release" in the README).
 
 ## [0.3.1] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+<!-- Add your change under the relevant category: Added / Changed / Deprecated / Removed / Fixed / Security. -->
+
 ## [0.3.1] - 2026-04-05
 
 ### Fixed
@@ -58,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release.
 
+[unreleased]: https://github.com/Schuwi/wikiwho_rs/compare/v0.3.1...HEAD
 [0.3.1]: https://github.com/Schuwi/wikiwho_rs/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Schuwi/wikiwho_rs/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Schuwi/wikiwho_rs/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ This is only beneficial for text where a significant portion of characters are n
 
 CI runs on GitHub Actions (`.github/workflows/`):
 
-- **`ci.yml`** (every push to `main` and every PR): `rustfmt`, Clippy across feature combinations (`-D warnings`), `cargo test --lib` + doc-tests, docs with warnings as errors, an MSRV check (Rust 1.94.1), coverage via `cargo-llvm-cov` (uploaded to Codecov), `cargo package`, a **SemVer check** (`cargo-semver-checks` over `--all-features` vs the latest crates.io release), and — the headline job — **deterministic parity against the reference Python WikiWho** (`algorithm_exact_tests`). Pull requests run parity against a small committed dump subset; pushes to `main` additionally fetch the full dump for deeper real-page parity.
+- **`ci.yml`** (every push to `main` and every PR): `rustfmt`, Clippy across feature combinations (`-D warnings`), `cargo test --lib` + doc-tests, docs with warnings as errors, an MSRV check (Rust 1.94.1), coverage via `cargo-llvm-cov` (uploaded to Codecov), `cargo package`, a **SemVer check** (`cargo-semver-checks` over `--all-features` vs the latest crates.io release), a **changelog check** (PRs must add an entry to `CHANGELOG.md`), and — the headline job — **deterministic parity against the reference Python WikiWho** (`algorithm_exact_tests`). Pull requests run parity against a small committed dump subset; pushes to `main` additionally fetch the full dump for deeper real-page parity.
   - The SemVer check enforces **continuous version bumping**: a PR that makes a breaking API change must bump `version` in `Cargo.toml` accordingly (for `0.x`, the minor field, e.g. `0.3.x` → `0.4.0`), or CI fails. Purely additive changes are not forced to bump.
 - **`fuzz.yml`** (weekly + manual): randomized property-test fuzzing of Rust-vs-Python parity. A failure uploads the discovered `*.proptest-regressions` seed so it can be committed as a permanent regression.
 - **`heavy.yml`** (manual only): big-history parity and the opt-in ~25 GB multithreaded parity test against the full dump.
@@ -338,6 +338,8 @@ By submitting a contribution, you agree that your code will be licensed under th
 
 - Fork the repository: [wikiwho_rs GitHub](https://github.com/Schuwi/wikiwho_rs)
 - Create a new branch for your feature or bug fix.
+- Add an entry under `## [Unreleased]` in [`CHANGELOG.md`](CHANGELOG.md) (Keep a Changelog format). CI enforces this; for changes that don't warrant an entry (CI, docs, refactors) a maintainer can apply the `skip-changelog` label.
+- If your change alters the public API in a breaking way, bump `version` in `Cargo.toml` (for `0.x`, the minor field) — the `semver` CI job checks this.
 - Submit a pull request with a clear description of your changes.
 
 ### Development Setup

--- a/README.md
+++ b/README.md
@@ -289,7 +289,8 @@ This is only beneficial for text where a significant portion of characters are n
 
 CI runs on GitHub Actions (`.github/workflows/`):
 
-- **`ci.yml`** (every push to `main` and every PR): `rustfmt`, Clippy across feature combinations (`-D warnings`), `cargo test --lib` + doc-tests, docs with warnings as errors, an MSRV check (Rust 1.94.1), coverage via `cargo-llvm-cov` (uploaded to Codecov), `cargo package`, and — the headline job — **deterministic parity against the reference Python WikiWho** (`algorithm_exact_tests`). Pull requests run parity against a small committed dump subset; pushes to `main` additionally fetch the full dump for deeper real-page parity.
+- **`ci.yml`** (every push to `main` and every PR): `rustfmt`, Clippy across feature combinations (`-D warnings`), `cargo test --lib` + doc-tests, docs with warnings as errors, an MSRV check (Rust 1.94.1), coverage via `cargo-llvm-cov` (uploaded to Codecov), `cargo package`, a **SemVer check** (`cargo-semver-checks` over `--all-features` vs the latest crates.io release), and — the headline job — **deterministic parity against the reference Python WikiWho** (`algorithm_exact_tests`). Pull requests run parity against a small committed dump subset; pushes to `main` additionally fetch the full dump for deeper real-page parity.
+  - The SemVer check enforces **continuous version bumping**: a PR that makes a breaking API change must bump `version` in `Cargo.toml` accordingly (for `0.x`, the minor field, e.g. `0.3.x` → `0.4.0`), or CI fails. Purely additive changes are not forced to bump.
 - **`fuzz.yml`** (weekly + manual): randomized property-test fuzzing of Rust-vs-Python parity. A failure uploads the discovered `*.proptest-regressions` seed so it can be committed as a permanent regression.
 - **`heavy.yml`** (manual only): big-history parity and the opt-in ~25 GB multithreaded parity test against the full dump.
 
@@ -297,6 +298,29 @@ Test data:
 
 - The representative subset (`dewiktionary-20240901-ci-subset.xml.zst`, ~900 KB) is committed via Git LFS, so contributors and CI get it on clone — no download needed. Regenerate it from a full dump with `python3 tools/make_ci_subset.py`.
 - The full 808 MB dump lives in the [`Schuwi/wikiwho-data`](https://github.com/Schuwi/wikiwho-data) release. Fetch it (checksum-verified) with `python3 tools/fetch_test_data.py --which full`.
+
+### Verifying a release
+
+Releases on [crates.io](https://crates.io/crates/wikiwho) are published by CI (not from a maintainer's machine), so they are independently verifiable. Each release is signed with an [SLSA build-provenance attestation](https://github.com/actions/attest-build-provenance). **Verify the artifact you actually install** — the `.crate` from crates.io (or the copy in your local `~/.cargo` cache):
+
+```sh
+ver=<version>
+# fetch the exact bytes crates.io serves
+curl -L -o "wikiwho-$ver.crate" "https://crates.io/api/v1/crates/wikiwho/$ver/download"
+
+# verify provenance, pinned to the release workflow, the version tag, and a GitHub-hosted runner
+gh attestation verify "wikiwho-$ver.crate" \
+  --repo Schuwi/wikiwho_rs \
+  --cert-identity "https://github.com/Schuwi/wikiwho_rs/.github/workflows/release.yml@refs/tags/v$ver" \
+  --deny-self-hosted-runners
+```
+
+`gh` fetches the attestation from GitHub by the file's content digest (crates.io does not serve it), so this **fails if the crates.io bytes were not built by this repo's release workflow** — including anything published out-of-band. The two pins check the signing certificate, the only part of an attestation a compromised build cannot forge:
+
+- `--cert-identity` — the exact build identity: produced by `release.yml` **at the `vX.Y.Z` tag**. Because this repo uses [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases), that tag is permanently locked to one commit, so pinning the tag also pins the source — no commit hash to look up. (`--repo` alone would accept an attestation from any workflow in the repo; this pins the workflow path *and* ref, which is also the build-signer identity.)
+- `--deny-self-hosted-runners` — built on a GitHub-hosted runner, not an attacker's self-hosted one.
+
+A pass proves the crate was produced by `release.yml` at tag `vX.Y.Z` on GitHub's infrastructure. If you want to go further: the attestation certificate also records the source commit (and the crate embeds `.cargo_vcs_info.json`), so you can open that commit on GitHub, confirm `release.yml` at it only packages and publishes, and diff the extracted crate against `git checkout v<version>`. Each immutable release additionally carries a GitHub-signed release attestation and a copy of the `.crate`, if you want a second, independent cross-link. Maintainers: see [`RELEASING.md`](RELEASING.md).
 
 ## Contributing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,131 @@
+# Releasing `wikiwho`
+
+Releases are published to crates.io by CI (`.github/workflows/release.yml`), triggered by a
+`v*` tag. There is no `CARGO_REGISTRY_TOKEN` anywhere — publishing uses crates.io
+[Trusted Publishing](https://crates.io/docs/trusted-publishing) (OIDC) — and a manual approval
+on the `release` GitHub Environment is required before anything is published.
+
+## Versioning (continuous bump)
+
+The `version` in `Cargo.toml` is kept as the *next* version to publish and is bumped in the PR
+that makes the change require it — not at release time. `ci.yml`'s `semver` job enforces this:
+`cargo-semver-checks` compares the public API against the latest crates.io release and fails the
+PR if the version doesn't reflect the change (`0.x` rules: a breaking change needs a minor bump,
+e.g. `0.3.x` → `0.4.0`). So by the time you release, `main` already carries a correct version.
+
+## Procedure
+
+1. Ensure `CHANGELOG.md` is up to date for the release, and `version` in `Cargo.toml` is the
+   version to publish (it was bumped in whichever PR introduced the breaking change).
+2. Merge to `main` and wait for CI (`ci.yml`) to go green.
+3. Tag that commit and push the tag:
+   ```sh
+   git tag vX.Y.Z && git push origin vX.Y.Z
+   ```
+4. Approve the pending `release` deployment on the Actions run. CI then runs the gates and
+   publishes.
+
+> **Always tag the tip of a green `main`.** The release refuses to publish unless `ci.yml`
+> succeeded for the *exact* tagged commit, and `ci.yml` only runs for the tip commit of a push
+> to `main`. Tagging an intermediate or off-`main` commit will be (correctly) blocked.
+
+## Gates (all must pass before publish)
+
+1. **Green CI** — the `ci.yml` run for the tagged commit must have concluded `success`. No checks
+   are re-run; the step polls up to 15 min in case the tag was pushed before CI finished. This is
+   what enforces SemVer at release time: ci.yml's `semver` job already checked the version against
+   the crates.io baseline for that commit (over `--all-features`, including `python-diff`).
+2. **Version == tag** — `Cargo.toml` version must equal the tag.
+
+`cargo publish` also performs a verification build of the packaged crate, so the published bytes
+are compile-verified even though the test suite is not re-run.
+
+## What a release produces
+
+Order of operations: run the gates, `cargo publish`, create the immutable GitHub release, then
+**attest last**. `cargo publish` leaves the exact uploaded tarball in `target/package/`; that one
+file is what gets attached to the release and attested, so the attestation subject, the release
+asset, and the crates.io bytes are identical **by construction** — no assumption that cargo
+packaging is byte-deterministic across invocations.
+
+**Attestation is deliberately the final step.** A valid build-provenance attestation for a tag can
+therefore exist only once the crate is actually on crates.io *and* the immutable release is
+published — there is never an orphan attestation binding a `.crate` to a tag that never shipped.
+The pipeline fails closed: if any step fails, at worst you get a published-but-unattested release
+(the consumer's verify fails safe), never an attestation for an artifact that isn't on crates.io.
+
+- **The crate on crates.io** via Trusted Publishing — the one canonical, consumed artifact. It
+  embeds `.cargo_vcs_info.json` for source correspondence.
+- **An immutable GitHub Release.** Publishing it locks the tag to the commit — which is what makes
+  consumer verification *by tag name* sound — and auto-generates a GitHub-signed release
+  attestation over the asset digest. The `.crate` is attached as an independent cross-link,
+  deliberately *not* the documented verification target.
+- **An SLSA build-provenance attestation** (Sigstore/Rekor), bound to the `.crate`'s content digest
+  and carrying the build identity (`release.yml@refs/tags/vX.Y.Z`, the runner environment, the
+  source commit). Retrieved by `gh attestation verify` from GitHub, not from crates.io.
+
+Publishing to crates.io *before* creating the immutable release means a publish failure strands
+nothing (no release is created, the version name stays reusable); the trade-off is that the tag is
+locked a moment after the crate appears on crates.io rather than before. OIDC auth is obtained just
+before `cargo publish` (the first irreversible step), so an auth failure is fully recoverable.
+
+Consumers verify the artifact they actually install — the crates.io download or their `~/.cargo`
+cache copy. See the README's "Verifying a release" section.
+
+> **First-release check.** On the first tagged release, run the README's verify command against the
+> published crate to confirm the whole chain works end to end (OIDC publish, `--cert-identity`
+> match, immutable release).
+
+## Security model and limitations
+
+Consumer verification (see the README's "Verifying a release") enforces everything against the
+attestation's **signing certificate** — via `--cert-identity` (the build identity: the `release.yml`
+workflow at the `vX.Y.Z` tag, which is also the build-signer identity) and `--deny-self-hosted-runners`
+(the runner environment). These certificate fields cannot be forged by a workflow even with its OIDC
+token; the SLSA `predicate` *can* be, so it is not relied on.
+
+Pinning the **tag** (rather than the commit) is sound because of two immutability backstops: the
+repo has **immutable releases** enabled, so a published tag is permanently locked to its commit and
+cannot be moved to a malicious commit and re-attested under the same `…@refs/tags/vX.Y.Z` identity;
+and a crates.io version can never be replaced once published. Because the workflow is **non-reusable
+and triggered only by a tag push**, the signer equals the source — so the single `--cert-identity`
+pin covers the build script, and there is no signer != source gap to check separately.
+
+What verification does and does not protect against:
+
+- **Wrong repo / wrong workflow / self-hosted runner → caught.** An artifact attested by a
+  different repo, a different workflow, or on a self-hosted runner fails the pinned verify.
+- **A hijacked `release.yml` → *not* caught by verification.** If an attacker runs code inside the
+  release job (a compromised build dependency, a tampered action, or an unreviewed change to
+  `release.yml`), the artifact genuinely carries this repo + workflow identity and passes every
+  flag. The defenses are upstream:
+  - the `release` environment's required-reviewer gate (no silent release);
+  - branch protection + CODEOWNERS on `main` and `.github/` so `release.yml` can't change unreviewed;
+  - third-party actions pinned to full commit SHAs in `release.yml` (Dependabot keeps them
+    current); the other workflows still use tags, which is lower-risk as they hold no publish or
+    signing credentials;
+  - least-privilege tokens and monitoring the public attestation/Rekor log.
+
+  It is also why a consumer's final step is to read `release.yml` *at the pinned commit*.
+
+Attestations are **not revocable.** Sigstore uses short-lived certificates and an append-only
+transparency log (Rekor), so there is no key or certificate to revoke and the log entry is
+permanent. Deleting an attestation from GitHub's store does not invalidate it (Rekor still has it;
+offline bundles still verify). The response to a bad-but-validly-signed release is to **yank** it
+on crates.io, file a RustSec advisory, and publish a fixed version — the transparency log aids
+detection and forensics, not revocation.
+
+## One-time setup (done)
+
+- crates.io Trusted Publishing: repo `Schuwi/wikiwho_rs`, workflow `release.yml`, environment
+  `release`.
+- GitHub Environment `release` with a required reviewer.
+- **Immutable releases** enabled (repo/org setting). Verification by tag name depends on this; if
+  it is ever disabled, fall back to pinning the commit (`--source-digest`, read from the
+  attestation certificate or the crate's `.cargo_vcs_info.json`).
+
+## Possible future additions
+
+- [`release-plz`](https://release-plz.dev) for automated version-bump + `CHANGELOG.md` "release
+  PRs" — most useful for workspaces or frequent releases; the current single-crate, hand-curated
+  flow is simpler and was kept deliberately.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,8 +15,11 @@ e.g. `0.3.x` → `0.4.0`). So by the time you release, `main` already carries a 
 
 ## Procedure
 
-1. Ensure `CHANGELOG.md` is up to date for the release, and `version` in `Cargo.toml` is the
-   version to publish (it was bumped in whichever PR introduced the breaking change).
+1. In `CHANGELOG.md`, rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`, add a fresh empty
+   `## [Unreleased]` above it, and update the link refs at the bottom (point `[unreleased]` at
+   `compare/vX.Y.Z...HEAD` and add `[X.Y.Z]`). The `[Unreleased]` entries were filled in per PR
+   (enforced by ci.yml's `changelog` job). Ensure `version` in `Cargo.toml` is the version to
+   publish (bumped in whichever PR introduced the breaking change).
 2. Merge to `main` and wait for CI (`ci.yml`) to go green.
 3. Tag that commit and push the tag:
    ```sh
@@ -123,6 +126,8 @@ detection and forensics, not revocation.
 - **Immutable releases** enabled (repo/org setting). Verification by tag name depends on this; if
   it is ever disabled, fall back to pinning the commit (`--source-digest`, read from the
   attestation certificate or the crate's `.cargo_vcs_info.json`).
+- A **`skip-changelog`** label, for PRs that don't warrant a `CHANGELOG.md` entry (the `changelog`
+  CI job is skipped when it's present; Dependabot PRs are exempt automatically via the actor check).
 
 ## Possible future additions
 


### PR DESCRIPTION
Adds an automated, provenance-backed release pipeline and two PR-quality gates.

## `release.yml` — tag-driven publish with verifiable provenance
Triggered by a `v*` tag; non-reusable and tag-only (so signer == source). Manual approval via the `release` environment.

- **Trusted Publishing (OIDC)** — no `CARGO_REGISTRY_TOKEN` anywhere.
- **Gates:** `ci.yml` green for the tagged commit (polls ≤15 min) + `Cargo.toml` version == tag.
- **Order:** auth → `cargo publish` → immutable GitHub release (attaches the exact uploaded `.crate`) → **attest last**. Attesting last means a valid attestation can only exist once both crates.io publish *and* the immutable release succeeded — no orphan attestation; the pipeline fails closed.
- **No determinism assumption:** attestation subject == release asset == crates.io bytes (one file).
- Third-party actions **SHA-pinned** (Dependabot-tracked); `dtolnay/rust-toolchain` dropped in favor of the preinstalled stable to keep the credentialed workflow lean.

Consumers verify the crates.io artifact by tag:
\`\`\`sh
gh attestation verify wikiwho-X.Y.Z.crate --repo Schuwi/wikiwho_rs \
  --cert-identity 'https://github.com/Schuwi/wikiwho_rs/.github/workflows/release.yml@refs/tags/vX.Y.Z' \
  --deny-self-hosted-runners
\`\`\`
Immutable releases lock tag→commit, so pinning the tag pins the source.

## `ci.yml` — SemVer gate (continuous version bumping)
`cargo-semver-checks` over `--all-features` (incl. `python-diff`; needs only a Python interpreter to build) vs the latest crates.io release. A PR with a breaking change must bump the version (`0.x`: the minor field). Lives in `ci.yml`, not the release path — and since `release.yml` requires `ci.yml` green for the tagged commit, SemVer is still enforced at release time.

## `ci.yml` — changelog gate
PRs must add an entry under `## [Unreleased]` in `CHANGELOG.md` (already Keep a Changelog format). Escape hatches: the `skip-changelog` label and automatic Dependabot exemption. Plain `git diff` + `grep`, no new action.

## Docs
`README` (Verifying a release, Contributing, CI section) and a new `RELEASING.md` (procedure, gates, security model, one-time setup).

## Maintainer setup
Done: Trusted Publishing, `release` environment, immutable releases. **Still needed:** create a `skip-changelog` label.

## Not exercisable until a real tag
The OIDC publish, immutable-release flow, and `--cert-identity` SAN match can only be confirmed on a live tag — a patch release (`v0.3.2`) is the safe first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)