### PR TITLE
fix: remove unreleased WIP bundled into the CI commit (d0ef62c)

### DIFF
--- a/src/bin/wikiwho-cli.rs
+++ b/src/bin/wikiwho-cli.rs
@@ -20,11 +20,10 @@ fn serialize_editor<S: serde::Serializer>(
     contributor: &&Contributor,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
-    // match contributor.id {
-    //     Some(id) if id != 0 => serializer.collect_str(&id),
-    //     _ => serializer.collect_str(&format_args!("0|{}", contributor.username)),
-    // }
-    serializer.collect_str(contributor.username.as_str())
+    match contributor.id {
+        Some(id) if id != 0 => serializer.collect_str(&id),
+        _ => serializer.collect_str(&format_args!("0|{}", contributor.username)),
+    }
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -45,15 +44,14 @@ Arguments:
                           Compression auto-detected from extension (.bz2, .zst, .gz)
 
 Options:
-  -o, --output PATH         Output file (omit or \"-\" for stdout)
-                            Compression auto-detected from extension (.bz2, .zst, .gz)
-  -f, --format FORMAT       Output format: jsonl (default), json, raw
-  -c, --compression-level N Compression level for output encoder, ignored if uncompressed
-  -j, --jobs N              Number of worker threads (default: number of CPUs)
-  -n, --namespace NS        Only process pages in this namespace (repeatable)
-  -N, --pages N             Only process the first N pages
-  -q, --quiet               Suppress progress messages on stderr
-  -h, --help                Show this help message"
+  -o, --output PATH       Output file (omit or \"-\" for stdout)
+                          Compression auto-detected from extension (.bz2, .zst, .gz)
+  -f, --format FORMAT     Output format: jsonl (default), json, raw
+  -j, --jobs N            Number of worker threads (default: number of CPUs)
+  -n, --namespace NS      Only process pages in this namespace (repeatable)
+  -N, --pages N           Only process the first N pages
+  -q, --quiet             Suppress progress messages on stderr
+  -h, --help              Show this help message"
     );
 }
 
@@ -74,12 +72,6 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         "output",
         "Output file (\"-\" or omit for stdout)",
         "PATH",
-    );
-    opts.optopt(
-        "c",
-        "compression-level",
-        "Compression level for output encoder",
-        "LEVEL",
     );
     opts.optopt(
         "f",
@@ -128,16 +120,6 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             .unwrap_or(1),
     };
 
-    let compression_level: Option<i32> = if let Some(level_str) = matches.opt_str("c") {
-        Some(
-            level_str
-                .parse::<i32>()
-                .map_err(|e| format!("invalid -c value: {e}"))?,
-        )
-    } else {
-        None
-    };
-
     let namespace_filter: Vec<i32> = matches
         .opt_strs("n")
         .iter()
@@ -179,45 +161,18 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             let file = std::fs::File::create(path)
                 .map_err(|e| format!("cannot create output '{path}': {e}"))?;
             if path.ends_with(".bz2") {
-                let compression = if let Some(level) = compression_level {
-                    u32::try_from(level)
-                        .ok()
-                        .and_then(bzip2::Compression::try_new)
-                        .ok_or_else(|| format!("invalid compression level for bzip2: {level}"))?
-                } else {
-                    bzip2::Compression::default()
-                };
-
                 Box::new(BufWriter::new(bzip2::write::BzEncoder::new(
                     file,
-                    compression,
+                    bzip2::Compression::default(),
                 )))
             } else if path.ends_with(".zst") || path.ends_with(".zstd") {
-                if matches!(compression_level, Some(level) if !(0..=22).contains(&level)) {
-                    return Err(format!(
-                        "invalid compression level for zstd: {}",
-                        compression_level.unwrap()
-                    )
-                    .into());
-                }
-
                 Box::new(BufWriter::new(
-                    zstd::Encoder::new(file, compression_level.unwrap_or(0))
-                        .map_err(|e| format!("zstd init: {e}"))?,
+                    zstd::Encoder::new(file, 3).map_err(|e| format!("zstd init: {e}"))?,
                 ))
             } else if path.ends_with(".gz") {
-                let compression = if let Some(level) = compression_level {
-                    u32::try_from(level)
-                        .ok()
-                        .map(flate2::Compression::new)
-                        .ok_or_else(|| format!("invalid compression level for gz: {level}"))?
-                } else {
-                    flate2::Compression::default()
-                };
-
                 Box::new(BufWriter::new(flate2::write::GzEncoder::new(
                     file,
-                    compression,
+                    flate2::Compression::default(),
                 )))
             } else {
                 Box::new(BufWriter::new(file))
@@ -768,7 +723,6 @@ fn write_page_result(
 /// PageAnalysis)>` cart, which keeps the borrowed data alive.
 #[derive(serde::Serialize, yoke::Yokeable)]
 struct PageOutput<'a> {
-    page_id: i32,
     article_title: &'a str,
     namespace: i32,
     revisions: Vec<RevisionOutput<'a>>,
@@ -837,7 +791,6 @@ fn build_page_output<'a>(page: &'a Page, analysis: &'a PageAnalysis) -> PageOutp
         .collect();
 
     PageOutput {
-        page_id: page.id,
         article_title: &page.title,
         namespace: page.namespace,
         revisions,

--- a/src/dump_parser/mod.rs
+++ b/src/dump_parser/mod.rs
@@ -697,7 +697,6 @@ impl<R: BufRead> DumpParser<R> {
         let span = tracing::span!(tracing::Level::DEBUG, "parse_page", self=?self, title=tracing::field::Empty);
 
         let mut page = Page {
-            id: 0,
             title: CompactString::default(),
             namespace: 0,
             revisions: Vec::new(),
@@ -784,19 +783,7 @@ impl<R: BufRead> DumpParser<R> {
                             }
                             span.record("title", page.title.as_str());
                         }
-                        [MediaWiki, Page, Id] => {
-                            page.id = if let Ok(id) = text.parse() {
-                                id
-                            } else {
-                                tracing::warn!(
-                                    message = "Found invalid page id, generating a random id",
-                                    id = text.as_ref(),
-                                    position = self.xml_parser.buffer_position()
-                                );
-                                // always use negative ids for invalid ids
-                                rand::rng().random_range(i32::MIN..-100)
-                            };
-                        }
+                        [MediaWiki, Page, Id] => { /* ignore page id */ }
                         [MediaWiki, Page, Ns] => {
                             let ns = if let Ok(id) = text.parse() {
                                 id
@@ -816,7 +803,7 @@ impl<R: BufRead> DumpParser<R> {
                                 revision_builder.id = if let Ok(id) = text.parse() {
                                     Some(id)
                                 } else {
-                                    tracing::warn!(
+                                    tracing::info!(
                                         message =
                                             "Found invalid revision id, generating a random id",
                                         id = text.as_ref(),

--- a/src/dump_parser/types.rs
+++ b/src/dump_parser/types.rs
@@ -88,7 +88,6 @@ pub struct Revision {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Page {
-    pub id: i32,
     pub title: CompactString,
     pub namespace: i32,
     pub revisions: Vec<Revision>,

--- a/tests/algorithm_exact_tests.rs
+++ b/tests/algorithm_exact_tests.rs
@@ -205,7 +205,6 @@ fn test_case_1() {
     // found by proptest
     Python::attach(|py| {
         let page = Page {
-            id: 0,
             title: "Test".into(),
             namespace: 0,
             revisions: vec![
@@ -257,7 +256,6 @@ fn test_case_1() {
 fn test_case_2() {
     // found by proptest
     let page = Page {
-        id: 0,
         title: "Test".into(),
         namespace: 0,
         revisions: vec![

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -877,7 +877,6 @@ pub mod proptest_support {
                 (revisions in correct_revision_vec(has_hash, text_strategy.clone(), max_revisions))
         -> Page {
             Page {
-                id: 0, /* ignored in algorithm */
                 title: "Pagetitle".into(), /* ignored in algorithm */
                 namespace: 0, /* ignored in algorithm */
                 revisions

--- a/tests/fixtures/exact-regressions/Anontalkpagetext_shortened.json
+++ b/tests/fixtures/exact-regressions/Anontalkpagetext_shortened.json
@@ -1,5 +1,4 @@
 {
-    "id": 168,
     "title": "Anontalkpagetext",
     "namespace": 0,
     "revisions": [


### PR DESCRIPTION
The `semver` gate from #13 surfaced that `main`'s public API drifted from the published 0.3.1 without a version bump. Root cause: **`d0ef62c` ("ci: add GitHub Actions CI …") folded in unfinished working-tree changes** — its own commit message even notes it. The bundled WIP:

| Change | Where | Kind |
|---|---|---|
| `pub id` field on `Page` (+ parsing/construction) | `dump_parser` | **breaking lib API** |
| `-c/--compression-level` option | `wikiwho-cli` (binary) | unfinished feature |
| `serialize_editor` real logic commented out → username only | `wikiwho-cli` (binary) | debugging hack |

Only `Page.id` affects library SemVer (the CLI bits are in the `[[bin]]`), but all of it was unfinished and unintended for release.

## What this PR does
Restores the affected files to their **v0.3.1** state, keeping only the genuine CI-enabling lint fixes (so `clippy -D warnings` still passes):

- removed: `Page.id` + its parsing/construction, the `-c` option, the `serialize_editor` hack
- kept: `optimized_str.rs` needless-borrow fix, `dump_parser/mod.rs` needless-return fix

After this, `src/` equals v0.3.1 except those two internal lint fixes — so the **public API matches 0.3.1 again** and the next release is a clean `0.3.2` patch.

Verified locally: `cargo fmt --check`, `clippy --all-targets … -D warnings`, `cargo test --lib`, doc tests — all green.

## Follow-ups (not in this PR)
- The removed work is recoverable from `d0ef62c` and can return as proper, reviewed feature PRs: **page-id tracking** (breaking → 0.4.0) and **output compression level** (additive), with `serialize_editor` finished rather than commented out.
- After this merges, #13 will be rebased onto the cleaned `main`, which makes its `semver` check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)