### PR TITLE
fix: verify-release crate download (User-Agent) + README improvements

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -46,12 +46,14 @@ jobs:
           echo "ver=$ver" >> "$GITHUB_OUTPUT"
           echo "Verifying release $tag (crate version $ver)"
 
-      # Mirror the README's consumer verification steps exactly.
       - name: Download .crate from crates.io
         env:
           VER: ${{ steps.ver.outputs.ver }}
         run: |
-          url="https://crates.io/api/v1/crates/wikiwho/${VER}/download"
+          # Use the static CDN URL directly. The crates.io API endpoint
+          # (crates.io/api/v1/crates/{name}/{version}/download) just redirects here,
+          # but returns 403 from GitHub Actions IPs due to bot detection.
+          url="https://static.crates.io/crates/wikiwho/wikiwho-${VER}.crate"
           echo "Downloading $url"
           curl -fsSL "$url" -o "wikiwho-${VER}.crate"
           echo "sha256: $(sha256sum "wikiwho-${VER}.crate" | cut -d' ' -f1)"

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -50,12 +50,11 @@ jobs:
         env:
           VER: ${{ steps.ver.outputs.ver }}
         run: |
-          # Use the static CDN URL directly. The crates.io API endpoint
-          # (crates.io/api/v1/crates/{name}/{version}/download) just redirects here,
-          # but returns 403 from GitHub Actions IPs due to bot detection.
-          url="https://static.crates.io/crates/wikiwho/wikiwho-${VER}.crate"
+          # crates.io requires a descriptive User-Agent; the default curl/X.Y.Z gets a 403.
+          url="https://crates.io/api/v1/crates/wikiwho/${VER}/download"
           echo "Downloading $url"
-          curl -fsSL "$url" -o "wikiwho-${VER}.crate"
+          curl -fsSL -A "wikiwho-verify (https://github.com/Schuwi/wikiwho_rs)" \
+            "$url" -o "wikiwho-${VER}.crate"
           echo "sha256: $(sha256sum "wikiwho-${VER}.crate" | cut -d' ' -f1)"
 
       - name: Verify build-provenance attestation

--- a/README.md
+++ b/README.md
@@ -317,6 +317,31 @@ gh attestation verify "wikiwho-$ver.crate" \
   --deny-self-hosted-runners
 ```
 
+A successful run looks like (digest and version tag will match your download):
+
+```
+Loaded digest sha256:24efbc63017eb2c7f0ca0086299752dfa3147d956b41ed0be726faf277b8ffd9 for file://wikiwho-0.3.3.crate
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- Predicate type must match:..................... https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:........ https://github.com/Schuwi
+- Source Repository URI must match:.............. https://github.com/Schuwi/wikiwho_rs
+- Subject Alternative Name must match:........... https://github.com/Schuwi/wikiwho_rs/.github/workflows/release.yml@refs/tags/v0.3.3
+- OIDC Issuer must match:........................ https://token.actions.githubusercontent.com
+- Action workflow Runner Environment must match : github-hosted
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... Schuwi/wikiwho_rs
+  - Build workflow:. .github/workflows/release.yml@refs/tags/v0.3.3
+  - Signer repo:.... Schuwi/wikiwho_rs
+  - Signer workflow: .github/workflows/release.yml@refs/tags/v0.3.3
+```
+
 `gh` fetches the attestation from GitHub by the file's content digest (crates.io does not serve it), so this **fails if the crates.io bytes were not built by this repo's release workflow** — including anything published out-of-band. The two pins check the signing certificate, the only part of an attestation a compromised build cannot forge:
 
 - `--cert-identity` — the exact build identity: produced by `release.yml` **at the `vX.Y.Z` tag**. Because this repo uses [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases), that tag is permanently locked to one commit, so pinning the tag also pins the source — no commit hash to look up. (`--repo` alone would accept an attestation from any workflow in the repo; this pins the workflow path *and* ref, which is also the build-signer identity.)

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Test data:
 Releases on [crates.io](https://crates.io/crates/wikiwho) are published by CI (not from a maintainer's machine), so they are independently verifiable. Each release is signed with an [SLSA build-provenance attestation](https://github.com/actions/attest-build-provenance). **Verify the artifact you actually install** — the `.crate` from crates.io (or the copy in your local `~/.cargo` cache):
 
 ```sh
-ver=<version>
+ver=0.3.3  # version number only, no leading 'v'
 # fetch the exact bytes crates.io serves (static CDN — the API redirect endpoint blocks curl)
 curl -o "wikiwho-$ver.crate" "https://static.crates.io/crates/wikiwho/wikiwho-$ver.crate"
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ gh attestation verify "wikiwho-$ver.crate" \
 
 A successful run looks like (digest and version tag will match your download):
 
-```
+```text
 Loaded digest sha256:24efbc63017eb2c7f0ca0086299752dfa3147d956b41ed0be726faf277b8ffd9 for file://wikiwho-0.3.3.crate
 Loaded 1 attestation from GitHub API
 

--- a/README.md
+++ b/README.md
@@ -305,8 +305,10 @@ Releases on [crates.io](https://crates.io/crates/wikiwho) are published by CI (n
 
 ```sh
 ver=X.Y.Z  # replace with the version number, no leading 'v'
-# fetch the exact bytes crates.io serves (static CDN — the API redirect endpoint blocks curl)
-curl -o "wikiwho-$ver.crate" "https://static.crates.io/crates/wikiwho/wikiwho-$ver.crate"
+# fetch the exact bytes crates.io serves (crates.io requires a descriptive User-Agent)
+curl -L -A "wikiwho-verify (https://github.com/Schuwi/wikiwho_rs)" \
+  -o "wikiwho-$ver.crate" \
+  "https://crates.io/api/v1/crates/wikiwho/$ver/download"
 
 # verify provenance, pinned to the release workflow, the version tag, and a GitHub-hosted runner
 gh attestation verify "wikiwho-$ver.crate" \

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Test data:
 Releases on [crates.io](https://crates.io/crates/wikiwho) are published by CI (not from a maintainer's machine), so they are independently verifiable. Each release is signed with an [SLSA build-provenance attestation](https://github.com/actions/attest-build-provenance). **Verify the artifact you actually install** — the `.crate` from crates.io (or the copy in your local `~/.cargo` cache):
 
 ```sh
-ver=0.3.3  # version number only, no leading 'v'
+ver=X.Y.Z  # replace with the version number, no leading 'v'
 # fetch the exact bytes crates.io serves (static CDN — the API redirect endpoint blocks curl)
 curl -o "wikiwho-$ver.crate" "https://static.crates.io/crates/wikiwho/wikiwho-$ver.crate"
 

--- a/README.md
+++ b/README.md
@@ -305,8 +305,8 @@ Releases on [crates.io](https://crates.io/crates/wikiwho) are published by CI (n
 
 ```sh
 ver=<version>
-# fetch the exact bytes crates.io serves
-curl -L -o "wikiwho-$ver.crate" "https://crates.io/api/v1/crates/wikiwho/$ver/download"
+# fetch the exact bytes crates.io serves (static CDN — the API redirect endpoint blocks curl)
+curl -o "wikiwho-$ver.crate" "https://static.crates.io/crates/wikiwho/wikiwho-$ver.crate"
 
 # verify provenance, pinned to the release workflow, the version tag, and a GitHub-hosted runner
 gh attestation verify "wikiwho-$ver.crate" \


### PR DESCRIPTION
## Summary

- **Root cause:** `crates.io/api/v1/…/download` returns 403 for the default `curl/X.Y.Z` User-Agent (bot detection). Adding `-A "wikiwho-verify (https://github.com/Schuwi/wikiwho_rs)"` gets the expected 302 redirect. Fixes both the `verify-release.yml` workflow and the README consumer instructions.
- **README:** updated the download snippet to use the proper User-Agent, clarified that `ver` takes the bare version number (no leading `v`), and added the expected `gh attestation verify` output so users know what success looks like.

## Test plan

- [ ] Trigger `verify-release.yml` via `workflow_dispatch` against `v0.3.3` and confirm it passes end-to-end
- [x] Run the README curl + `gh attestation verify` snippet locally and confirm the output matches the example

🤖 Generated with [Claude Code](https://claude.com/claude-code)