### PR TITLE
chore(release): prepare v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.3] - 2026-06-15
+## [0.3.4] - 2026-06-15
 
 ### Added
 
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated `pyo3` to `v0.29.0`.
+
+## [0.3.3] - 2026-06-15
+
+**Yanked**
 
 ## [0.3.2] - 2026-06-15
 
@@ -74,7 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release.
 
-[unreleased]: https://github.com/Schuwi/wikiwho_rs/compare/v0.3.3...HEAD
+[unreleased]: https://github.com/Schuwi/wikiwho_rs/compare/v0.3.4...HEAD
+[0.3.4]: https://github.com/Schuwi/wikiwho_rs/compare/v0.3.1...v0.3.4
 [0.3.3]: https://github.com/Schuwi/wikiwho_rs/compare/v0.3.1...v0.3.3
 [0.3.2]: https://github.com/Schuwi/wikiwho_rs/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/Schuwi/wikiwho_rs/compare/v0.3.0...v0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "wikiwho"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aho-corasick",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wikiwho"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MPL-2.0 AND MIT"


### PR DESCRIPTION
I forgot to enable immutable releases. Also the CHANGELOG.md was not correct (missing links).

Thus I yanked 0.3.3 and am preparing 0.3.4, this time properly.