### PR TITLE
docs: restructure README — split out SECURITY.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to wikiwho
+
+Contributions are welcome! Here are some ways you can help:
+
+- **Testing**: Try the library with different Wikimedia projects, languages, and dump versions.
+- **Benchmarking**: Assist in creating benchmarks to compare performance and accuracy.
+- **Documentation**: Improve existing documentation or add new examples and guides.
+- **Feature Development**: Help implement new features like resumable parsing or configuration options.
+- **Parser Enhancements**: Work on separating the parser into its own crate or improving its capabilities.
+
+By submitting a contribution, you agree that your code will be licensed under this project's license.
+
+## Getting Started
+
+- Fork the repository: [wikiwho_rs GitHub](https://github.com/Schuwi/wikiwho_rs)
+- Create a new branch for your feature or bug fix.
+- Add an entry under `## [Unreleased]` in [`CHANGELOG.md`](CHANGELOG.md) (Keep a Changelog format). CI enforces this; for changes that don't warrant an entry (CI, docs, refactors) a maintainer can apply the `skip-changelog` label.
+- If your change alters the public API in a breaking way, bump `version` in `Cargo.toml` (for `0.x`, the minor field) — the `semver` CI job checks this.
+- Submit a pull request with a clear description of your changes.
+
+## Development Setup
+
+The exact comparison tests call into the original Python WikiWho implementation to validate results, so a Python virtual environment must be active when running them. Without it, tests will fail with cryptic Python/pyo3 errors.
+
+```sh
+python -m venv venv
+source venv/bin/activate   # on Windows: venv\Scripts\activate
+pip install -r requirements.txt
+cargo test --features python-diff
+```
+
+To control where large temporary IPC files are written, set `TMPDIR` before running:
+
+```sh
+TMPDIR=/path/with/space cargo test --features python-diff
+```
+
+## Testing and Validation
+
+- **Exact comparison tests** (`algorithm_exact_tests.rs`): Compare the Rust implementation's results against the original Python WikiWho, token by token. These require the `python-diff` feature so that both implementations use the same diff algorithm. Run them with `cargo test --features python-diff`.
+- **Statistical comparison tests** (`algorithm_statistic_tests.rs`): Ignored by default and require local benchmark data. Fetch the archived partial gold standard with `python3 tools/fetch_gold_standard.py`, place current Wikimedia dump shards into `dev-data/extra-dumps/`, then run with `cargo test gold_standard_precision_rust -- --ignored` or `cargo test --features python-diff divergence_rate_gold_standard_articles -- --ignored`. See `dev-data/README.md` for details. CI runs these against a committed cache of gold-standard article histories (the pure-Rust precision test on every PR; the python-diff baselines on push to `main`).
+- **Temporary files**: Some tests use temporary files for IPC coordination between Rust and Python. These files can be large depending on the input dump. Their location follows `std::env::temp_dir()`, which can be controlled by setting the `TMPDIR` environment variable.
+- **Test dump location**: Real-page tests read a reference dump; set `WIKIWHO_TEST_DUMP=/path/to/dump.xml.zst` to override the default path. If the dump is absent, those tests skip (with a `SKIP:` notice) instead of failing.
+- **Community Feedback**: Seeking input from users testing with different languages and datasets.
+
+### Continuous Integration
+
+CI runs on GitHub Actions (`.github/workflows/`):
+
+- **`ci.yml`** (every push to `main` and every PR): `rustfmt`, Clippy across feature combinations (`-D warnings`), `cargo test --lib` + doc-tests, docs with warnings as errors, an MSRV check (Rust 1.94.1), coverage via `cargo-llvm-cov` (uploaded to Codecov), `cargo package`, a **SemVer check** (`cargo-semver-checks` over `--all-features` vs the latest crates.io release), a **changelog check** (PRs must add an entry to `CHANGELOG.md`), and — the headline jobs — **deterministic parity against the reference Python WikiWho** (`algorithm_exact_tests`) and **accuracy against the paper's gold standard** (`algorithm_statistic_tests`). Pull requests run parity against a small committed dump subset and the pure-Rust gold-standard precision test; pushes to `main` additionally fetch the full dump for deeper real-page parity and run the python-diff gold-standard baselines.
+  - The SemVer check enforces **continuous version bumping**: a PR that makes a breaking API change must bump `version` in `Cargo.toml` accordingly (for `0.x`, the minor field, e.g. `0.3.x` → `0.4.0`), or CI fails. Purely additive changes are not forced to bump.
+- **`fuzz.yml`** (weekly + manual): randomized property-test fuzzing of Rust-vs-Python parity. A failure uploads the discovered `*.proptest-regressions` seed so it can be committed as a permanent regression.
+- **`heavy.yml`** (manual only): big-history parity and the opt-in ~25 GB multithreaded parity test against the full dump.
+
+Test data:
+
+- The representative subset (`dewiktionary-20240901-ci-subset.xml.zst`, ~900 KB) is committed via Git LFS, so contributors and CI get it on clone — no download needed. Regenerate it from a full dump with `python3 tools/make_ci_subset.py`.
+- The full 808 MB dump lives in the [`Schuwi/wikiwho-data`](https://github.com/Schuwi/wikiwho-data) release. Fetch it (checksum-verified) with `python3 tools/fetch_test_data.py --which full`.
+
+## Project Status and Support
+
+- **Current Maintainer**: Working independently with assistance from various tools and collaborations.
+- **Versioning**: Follows semantic versioning. Expect potential breaking changes before reaching 1.0.0.
+- **Updates**: Development is on-demand. Regular maintenance depends on community interest and contributions.
+
+Maintainers cutting a release should see [`RELEASING.md`](RELEASING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Test data:
 
 ## Project Status and Support
 
-- **Current Maintainer**: Working independently with assistance from various tools and collaborations.
+- **Maintainer**: [@Schuwi](https://github.com/Schuwi), working independently.
 - **Versioning**: Follows semantic versioning. Expect potential breaking changes before reaching 1.0.0.
 - **Updates**: Development is on-demand. Regular maintenance depends on community interest and contributions.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A high-performance Rust implementation of the WikiWho algorithm for token-level 
 
 ## Overview
 
-`wikiwho` is a Rust library that implements the [WikiWho algorithm](https://github.com/wikiwho/WikiWho), enabling users to track authorship on a token level (token ≈ word) across all revisions of a Wikimedia page (e.g., Wikipedia, Wiktionary). It reimplements the original algorithm by Fabian Flöck and Maribel Acosta with significant performance improvements, allowing for efficient processing of entire Wikipedia/Wiktionary XML dumps.
+`wikiwho` is a Rust library that implements the [WikiWho algorithm](https://github.com/wikiwho/WikiWho), enabling users to track authorship on a token level (token ≈ word) across all revisions of a Wikimedia page (e.g., Wikipedia, Wiktionary). It reimplements the original algorithm by Fabian Flöck and Maribel Acosta with significant performance improvements: it processes an entire German Wiktionary dump (~1.3 million pages) in just under 4 minutes on 8 cores, where the original Python implementation managed roughly 300 pages per minute.
 
 **Key Features:**
 
@@ -26,13 +26,9 @@ A high-performance Rust implementation of the WikiWho algorithm for token-level 
 - **Modular Design**: Separate parser and algorithm modules that can be used independently.
 - **Faithful Implementation**: Aims to provide results comparable to the original algorithm, with an option to use the original Python diff algorithm for exact comparisons.
 
-<div class="rustdoc-hidden">
+## Validation
 
-## Motivation
-
-The original Python implementation of WikiWho could process about 300 pages in one to two minutes. In contrast, `wikiwho_rs` can process an entire German Wiktionary dump (approximately 1.3 million pages) in just under 4 minutes using 8 processor cores. This performance boost makes large-scale authorship analysis feasible and efficient.
-
-</div>
+CI verifies exact token-level parity against the reference Python WikiWho on every PR, and ≥85% precision against the paper's gold standard (the paper reports ~95% using Python's `difflib`; enable the `python-diff` feature for byte-identical results). Property-test fuzzing additionally checks Rust-vs-Python parity on randomized input. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for how to run these tests locally.
 
 ## Installation
 
@@ -270,135 +266,19 @@ This is only beneficial for text where a significant portion of characters are n
 
 <div class="rustdoc-hidden">
 
-## Future Plans
-
-- **Benchmarking**: Implement rigorous benchmarks comparing performance with the original Python implementation.
-- **Parser Improvements**: Consider separating the parser into a standalone crate.
-- **Resumable Parsing**: Potentially add support for processing pages in chunks and resuming analysis.
-- **Configuration Options**: Expose constants and settings within the algorithm for greater control.
-
-## Testing and Validation
-
-- **Exact comparison tests** (`algorithm_exact_tests.rs`): Compare the Rust implementation's results against the original Python WikiWho, token by token. These require the `python-diff` feature so that both implementations use the same diff algorithm. Run them with `cargo test --features python-diff`.
-- **Statistical comparison tests** (`algorithm_statistic_tests.rs`): Ignored by default and require local benchmark data. Fetch the archived partial gold standard with `python3 tools/fetch_gold_standard.py`, place current Wikimedia dump shards into `dev-data/extra-dumps/`, then run with `cargo test gold_standard_precision_rust -- --ignored` or `cargo test --features python-diff divergence_rate_gold_standard_articles -- --ignored`. See `dev-data/README.md` for details. CI runs these against a committed cache of gold-standard article histories (the pure-Rust precision test on every PR; the python-diff baselines on push to `main`).
-- **Temporary files**: Some tests use temporary files for IPC coordination between Rust and Python. These files can be large depending on the input dump. Their location follows `std::env::temp_dir()`, which can be controlled by setting the `TMPDIR` environment variable.
-- **Test dump location**: Real-page tests read a reference dump; set `WIKIWHO_TEST_DUMP=/path/to/dump.xml.zst` to override the default path. If the dump is absent, those tests skip (with a `SKIP:` notice) instead of failing.
-- **Community Feedback**: Seeking input from users testing with different languages and datasets.
-
-### Continuous Integration
-
-CI runs on GitHub Actions (`.github/workflows/`):
-
-- **`ci.yml`** (every push to `main` and every PR): `rustfmt`, Clippy across feature combinations (`-D warnings`), `cargo test --lib` + doc-tests, docs with warnings as errors, an MSRV check (Rust 1.94.1), coverage via `cargo-llvm-cov` (uploaded to Codecov), `cargo package`, a **SemVer check** (`cargo-semver-checks` over `--all-features` vs the latest crates.io release), a **changelog check** (PRs must add an entry to `CHANGELOG.md`), and — the headline jobs — **deterministic parity against the reference Python WikiWho** (`algorithm_exact_tests`) and **accuracy against the paper's gold standard** (`algorithm_statistic_tests`). Pull requests run parity against a small committed dump subset and the pure-Rust gold-standard precision test; pushes to `main` additionally fetch the full dump for deeper real-page parity and run the python-diff gold-standard baselines.
-  - The SemVer check enforces **continuous version bumping**: a PR that makes a breaking API change must bump `version` in `Cargo.toml` accordingly (for `0.x`, the minor field, e.g. `0.3.x` → `0.4.0`), or CI fails. Purely additive changes are not forced to bump.
-- **`fuzz.yml`** (weekly + manual): randomized property-test fuzzing of Rust-vs-Python parity. A failure uploads the discovered `*.proptest-regressions` seed so it can be committed as a permanent regression.
-- **`heavy.yml`** (manual only): big-history parity and the opt-in ~25 GB multithreaded parity test against the full dump.
-
-Test data:
-
-- The representative subset (`dewiktionary-20240901-ci-subset.xml.zst`, ~900 KB) is committed via Git LFS, so contributors and CI get it on clone — no download needed. Regenerate it from a full dump with `python3 tools/make_ci_subset.py`.
-- The full 808 MB dump lives in the [`Schuwi/wikiwho-data`](https://github.com/Schuwi/wikiwho-data) release. Fetch it (checksum-verified) with `python3 tools/fetch_test_data.py --which full`.
-
-### Verifying a release
-
-Releases on [crates.io](https://crates.io/crates/wikiwho) are published by CI (not from a maintainer's machine), so they are independently verifiable. Each release is signed with an [SLSA build-provenance attestation](https://github.com/actions/attest-build-provenance). **Verify the artifact you actually install** — the `.crate` from crates.io (or the copy in your local `~/.cargo` cache):
-
-```sh
-ver=X.Y.Z  # replace with the version number, no leading 'v'
-# fetch the exact bytes crates.io serves (crates.io requires a descriptive User-Agent)
-curl -L -A "wikiwho-verify (https://github.com/Schuwi/wikiwho_rs)" \
-  -o "wikiwho-$ver.crate" \
-  "https://crates.io/api/v1/crates/wikiwho/$ver/download"
-
-# verify provenance, pinned to the release workflow, the version tag, and a GitHub-hosted runner
-gh attestation verify "wikiwho-$ver.crate" \
-  --repo Schuwi/wikiwho_rs \
-  --cert-identity "https://github.com/Schuwi/wikiwho_rs/.github/workflows/release.yml@refs/tags/v$ver" \
-  --deny-self-hosted-runners
-```
-
-A successful run looks like (digest and version tag will match your download):
-
-```text
-Loaded digest sha256:24efbc63017eb2c7f0ca0086299752dfa3147d956b41ed0be726faf277b8ffd9 for file://wikiwho-0.3.3.crate
-Loaded 1 attestation from GitHub API
-
-The following policy criteria will be enforced:
-- Predicate type must match:..................... https://slsa.dev/provenance/v1
-- Source Repository Owner URI must match:........ https://github.com/Schuwi
-- Source Repository URI must match:.............. https://github.com/Schuwi/wikiwho_rs
-- Subject Alternative Name must match:........... https://github.com/Schuwi/wikiwho_rs/.github/workflows/release.yml@refs/tags/v0.3.3
-- OIDC Issuer must match:........................ https://token.actions.githubusercontent.com
-- Action workflow Runner Environment must match : github-hosted
-
-✓ Verification succeeded!
-
-The following 1 attestation matched the policy criteria
-
-- Attestation #1
-  - Build repo:..... Schuwi/wikiwho_rs
-  - Build workflow:. .github/workflows/release.yml@refs/tags/v0.3.3
-  - Signer repo:.... Schuwi/wikiwho_rs
-  - Signer workflow: .github/workflows/release.yml@refs/tags/v0.3.3
-```
-
-`gh` fetches the attestation from GitHub by the file's content digest (crates.io does not serve it), so this **fails if the crates.io bytes were not built by this repo's release workflow** — including anything published out-of-band. The two pins check the signing certificate, the only part of an attestation a compromised build cannot forge:
-
-- `--cert-identity` — the exact build identity: produced by `release.yml` **at the `vX.Y.Z` tag**. Because this repo uses [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases), that tag is permanently locked to one commit, so pinning the tag also pins the source — no commit hash to look up. (`--repo` alone would accept an attestation from any workflow in the repo; this pins the workflow path *and* ref, which is also the build-signer identity.)
-- `--deny-self-hosted-runners` — built on a GitHub-hosted runner, not an attacker's self-hosted one.
-
-A pass proves the crate was produced by `release.yml` at tag `vX.Y.Z` on GitHub's infrastructure. If you want to go further: the attestation certificate also records the source commit (and the crate embeds `.cargo_vcs_info.json`), so you can open that commit on GitHub, confirm `release.yml` at it only packages and publishes, and diff the extracted crate against `git checkout v<version>`. Each immutable release additionally carries a GitHub-signed release attestation and a copy of the `.crate`, if you want a second, independent cross-link. Maintainers: see [`RELEASING.md`](RELEASING.md).
-
 ## Contributing
 
-Contributions are welcome! Here are some ways you can help:
+Contributions are welcome — see [`CONTRIBUTING.md`](CONTRIBUTING.md) for ways to help, development setup, the test suite, and CI.
 
-- **Testing**: Try the library with different Wikimedia projects, languages, and dump versions.
-- **Benchmarking**: Assist in creating benchmarks to compare performance and accuracy.
-- **Documentation**: Improve existing documentation or add new examples and guides.
-- **Feature Development**: Help implement new features like resumable parsing or configuration options.
-- **Parser Enhancements**: Work on separating the parser into its own crate or improving its capabilities.
+## Security
 
-By submitting a contribution, you agree that your code will be licensed under this project’s license.
-
-### Getting Started
-
-- Fork the repository: [wikiwho_rs GitHub](https://github.com/Schuwi/wikiwho_rs)
-- Create a new branch for your feature or bug fix.
-- Add an entry under `## [Unreleased]` in [`CHANGELOG.md`](CHANGELOG.md) (Keep a Changelog format). CI enforces this; for changes that don't warrant an entry (CI, docs, refactors) a maintainer can apply the `skip-changelog` label.
-- If your change alters the public API in a breaking way, bump `version` in `Cargo.toml` (for `0.x`, the minor field) — the `semver` CI job checks this.
-- Submit a pull request with a clear description of your changes.
-
-### Development Setup
-
-The exact comparison tests call into the original Python WikiWho implementation to validate results, so a Python virtual environment must be active when running them. Without it, tests will fail with cryptic Python/pyo3 errors.
-
-```sh
-python -m venv venv
-source venv/bin/activate   # on Windows: venv\Scripts\activate
-pip install -r requirements.txt
-cargo test --features python-diff
-```
-
-To control where large temporary IPC files are written, set `TMPDIR` before running:
-
-```sh
-TMPDIR=/path/with/space cargo test --features python-diff
-```
-
-## Development and Support
-
-- **Current Maintainer**: Working independently with assistance from various tools and collaborations.
-- **Versioning**: Will follow semantic versioning. Expect potential breaking changes before reaching 1.0.0.
-- **Updates**: Development is on-demand. Regular maintenance depends on community interest and contributions.
+Releases carry [SLSA build-provenance attestations](https://github.com/actions/attest-build-provenance) and can be independently verified — see [`SECURITY.md`](SECURITY.md) for how to verify a release and how to report a vulnerability.
 
 </div>
 
 ## Acknowledgments
 
-This library was developed through a mix of hard work, creativity, and collaboration with various tools, including GitHub Copilot, ChatGPT and Claude Code. It has been an exciting journey filled with coding and brainstorming 💛.
-
-Special thanks to the friendly guidance and support of ChatGPT along the way, helping with documentation and understanding the original implementation to make this library as robust and performant as possible.
+This library reimplements the [WikiWho algorithm](https://github.com/wikiwho/WikiWho) originally created by Fabian Flöck and Maribel Acosta. Development was assisted by various AI coding tools.
 
 ## Licensing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,64 @@
+# Security Policy
+
+`wikiwho` is a library for parsing and analyzing Wikimedia XML dumps. It performs
+no network access and requires no special privileges, so its main security
+surface is robustness against malformed or hostile input (for example, a crafted
+dump that makes the parser crash, hang, or allocate unbounded memory).
+
+## Reporting a vulnerability
+
+Please report security-relevant issues privately via GitHub's
+["Report a vulnerability"](https://github.com/Schuwi/wikiwho_rs/security/advisories/new)
+form rather than opening a public issue. For ordinary parsing bugs that aren't
+security-sensitive, a normal [issue](https://github.com/Schuwi/wikiwho_rs/issues)
+is fine.
+
+## Verifying a release
+
+Releases on [crates.io](https://crates.io/crates/wikiwho) are published by CI (not from a maintainer's machine), so they are independently verifiable. Each release is signed with an [SLSA build-provenance attestation](https://github.com/actions/attest-build-provenance). **Verify the artifact you actually install** — the `.crate` from crates.io (or the copy in your local `~/.cargo` cache):
+
+```sh
+ver=X.Y.Z  # replace with the version number, no leading 'v'
+# fetch the exact bytes crates.io serves (crates.io requires a descriptive User-Agent)
+curl -L -A "wikiwho-verify (https://github.com/Schuwi/wikiwho_rs)" \
+  -o "wikiwho-$ver.crate" \
+  "https://crates.io/api/v1/crates/wikiwho/$ver/download"
+
+# verify provenance, pinned to the release workflow, the version tag, and a GitHub-hosted runner
+gh attestation verify "wikiwho-$ver.crate" \
+  --repo Schuwi/wikiwho_rs \
+  --cert-identity "https://github.com/Schuwi/wikiwho_rs/.github/workflows/release.yml@refs/tags/v$ver" \
+  --deny-self-hosted-runners
+```
+
+A successful run looks like (digest and version tag will match your download):
+
+```text
+Loaded digest sha256:24efbc63017eb2c7f0ca0086299752dfa3147d956b41ed0be726faf277b8ffd9 for file://wikiwho-0.3.3.crate
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- Predicate type must match:..................... https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:........ https://github.com/Schuwi
+- Source Repository URI must match:.............. https://github.com/Schuwi/wikiwho_rs
+- Subject Alternative Name must match:........... https://github.com/Schuwi/wikiwho_rs/.github/workflows/release.yml@refs/tags/v0.3.3
+- OIDC Issuer must match:........................ https://token.actions.githubusercontent.com
+- Action workflow Runner Environment must match : github-hosted
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... Schuwi/wikiwho_rs
+  - Build workflow:. .github/workflows/release.yml@refs/tags/v0.3.3
+  - Signer repo:.... Schuwi/wikiwho_rs
+  - Signer workflow: .github/workflows/release.yml@refs/tags/v0.3.3
+```
+
+`gh` fetches the attestation from GitHub by the file's content digest (crates.io does not serve it), so this **fails if the crates.io bytes were not built by this repo's release workflow** — including anything published out-of-band. The two pins check the signing certificate, the only part of an attestation a compromised build cannot forge:
+
+- `--cert-identity` — the exact build identity: produced by `release.yml` **at the `vX.Y.Z` tag**. Because this repo uses [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases), that tag is permanently locked to one commit, so pinning the tag also pins the source — no commit hash to look up. (`--repo` alone would accept an attestation from any workflow in the repo; this pins the workflow path *and* ref, which is also the build-signer identity.)
+- `--deny-self-hosted-runners` — built on a GitHub-hosted runner, not an attacker's self-hosted one.
+
+A pass proves the crate was produced by `release.yml` at tag `vX.Y.Z` on GitHub's infrastructure. If you want to go further: the attestation certificate also records the source commit (and the crate embeds `.cargo_vcs_info.json`), so you can open that commit on GitHub, confirm `release.yml` at it only packages and publishes, and diff the extracted crate against `git checkout v<version>`. Each immutable release additionally carries a GitHub-signed release attestation and a copy of the `.crate`, if you want a second, independent cross-link. Maintainers: see [`RELEASING.md`](RELEASING.md).


### PR DESCRIPTION
Closes #21.

Trims the README from **417 → 297 lines** to a user-facing landing page and moves contributor/maintainer/supply-chain material into dedicated files. Pure relocation + light editing — **no API or code changes**.

## README
- **Folded "Motivation" into Overview** as a single sentence, keeping the "~1.3M pages in <4 min on 8 cores" throughput stat.
- **Promoted a visible `## Validation` section** out of `rustdoc-hidden` — fixes the "rustdoc-hidden paradox" where the evidence of correctness (parity, ≥85% gold-standard precision, fuzzing) was hidden from exactly the docs.rs/crates.io visitors deciding whether to trust the crate.
- **Removed "Future Plans"** (its items are already tracked as #4 and #5).
- **Replaced** the large hidden block (Testing / CI / Verifying-a-release / Contributing / Dev-Setup / Support) with two short stubs — `## Contributing` → `CONTRIBUTING.md` and `## Security` → `SECURITY.md` — kept inside `rustdoc-hidden` so docs.rs stays API-focused while GitHub/crates.io still surface the links.
- **Trimmed Acknowledgments** to one line, keeping attribution to the original WikiWho authors (Flöck & Acosta).

## New files
- **`SECURITY.md`** — the full SLSA "Verifying a release" walkthrough, plus a brief "Reporting a vulnerability" pointer to GitHub's private advisory form.
- **`CONTRIBUTING.md`** — ways to help, Getting Started, Development Setup, Testing & Validation mechanics, Continuous Integration, and Project Status/Support.

## Verification
- `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings` → clean.
- `cargo test --doc --all-features` → 4 passed, 6 ignored, 0 failed (README examples still compile via `include_str!`).
- `rustdoc-hidden` divs balanced (3 open / 3 close); `src/lib.rs:5` still `include_str!`s the README.
- CHANGELOG untouched — this PR carries `skip-changelog`.

> **One judgment call:** issue #21 only asked to *move* "Verifying a release" into `SECURITY.md`, but since GitHub's Security tab surfaces that file I added a short "Reporting a vulnerability" section pointing to the private advisory form. Easy to drop or re-route if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)