### PR TITLE
docs: fix README user-facing accuracy (feature table, deps, MSRV, examples)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.3] - 2026-06-15
 
-**Yanked** — released before immutable releases were enabled on crates.io and with
+**Yanked** — released before immutable releases (a GitHub feature) were enabled and with
 incorrect/missing CHANGELOG links; superseded by an otherwise-identical 0.3.4.
 
 ## [0.3.2] - 2026-06-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.3] - 2026-06-15
 
-**Yanked**
+**Yanked** — released before immutable releases were enabled on crates.io and with
+incorrect/missing CHANGELOG links; superseded by an otherwise-identical 0.3.4.
 
 ## [0.3.2] - 2026-06-15
 
-**Yanked**
+**Yanked** — the release workflow failed to attach a build-provenance attestation (a
+cargo 1.96 change moved the packaged `.crate` to a path the CI glob no longer matched),
+so the published crate could not be verified as documented.
 
 ## [0.3.1] - 2026-04-05
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ CI verifies exact token-level parity against the reference Python WikiWho on eve
 wikiwho = "0.3"
 ```
 
+Requires Rust ≥ 1.94.1 (MSRV). The only feature enabled by default is `optimized-str`; see
+[Features and Configuration](#features-and-configuration) for the full list.
+
 ## Usage
 
 ### Basic Example
@@ -46,8 +49,9 @@ wikiwho = "0.3"
 Here's a minimal example of how to load a Wikimedia XML dump and analyze a page:
 
 ```rust,no_run
-use wikiwho::dump_parser::{DumpParser, Revision};
+use wikiwho::dump_parser::{Contributor, DumpParser};
 use wikiwho::algorithm::PageAnalysis;
+use wikiwho::utils::iterate_revision_tokens;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
@@ -57,24 +61,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let reader = BufReader::new(xml_dump);
     let mut parser = DumpParser::new(reader)?;
 
-    // Parse a single page
+    // Parse and analyze a single page.
     if let Some(page) = parser.parse_page()? {
-        // Analyze the page revisions
         let analysis = PageAnalysis::analyse_page(&page.revisions)?;
 
-        let revisions_by_id: HashMap<i32, Revision> = page.revisions.into_iter()
-            .map(|rev| (rev.id, rev))
+        // The analysis records the *id* of the revision that introduced each token
+        // (`analysis.revisions_by_id` maps those ids to per-revision analysis data).
+        // Editor names, however, live on the parsed revisions, so build a quick
+        // id -> contributor lookup from them:
+        let contributors: HashMap<i32, &Contributor> = page
+            .revisions
+            .iter()
+            .map(|rev| (rev.id, &rev.contributor))
             .collect();
 
-        // Iterate over tokens in the current revision
-        for token in wikiwho::utils::iterate_revision_tokens(&analysis, &analysis.current_revision) {
-            let token_analysis = &analysis[token];
-            let origin_revision_xml = &revisions_by_id[&token_analysis.origin_revision.id];
-            println!(
-                "'{}' by '{}'",
-                token.value.as_str(),
-                origin_revision_xml.contributor.username
-            );
+        // Walk the tokens of the current (latest) revision and print who first
+        // introduced each one.
+        for token in iterate_revision_tokens(&analysis, &analysis.current_revision) {
+            let origin_id = analysis[token].origin_revision.id;
+            let contributor = contributors[&origin_id];
+
+            // For anonymous edits `contributor.id` is `None` and
+            // `contributor.username` holds the editor's IP address.
+            println!("'{}' by '{}'", token.value.as_str(), contributor.username);
         }
     }
 
@@ -110,66 +119,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### Parallel Processing
 
-While XML parsing is inherently linear, you can process pages in parallel once they are parsed:
+XML parsing is inherently linear, but analysis is independent per page and parallelizes
+cleanly. The usual pattern is:
 
-- Run the parser in a single thread.
-- Distribute parsed pages to worker threads for analysis.
-- Use threading libraries like `std::thread` or crates like `rayon` for concurrency.
+- Run the parser on a single thread.
+- Hand each parsed `Page` off to a worker pool.
+- Call `PageAnalysis::analyse_page` on each page in parallel and collect the results.
 
-**Example using multiple threads:**
-
-```rust,no_run
-use wikiwho::dump_parser::{DumpParser, Page};
-use wikiwho::algorithm::PageAnalysis;
-use std::fs::File;
-use std::io::BufReader;
-use std::sync::{mpsc::channel, Arc, Mutex};
-use std::thread;
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let xml_dump = File::open("path/to/pages-meta-history.xml")?;
-    let reader = BufReader::new(xml_dump);
-    let mut parser = DumpParser::new(reader)?;
-
-    // Channel to send pages to worker threads
-    let (tx, rx) = channel::<Page>();
-    let rx = Arc::new(Mutex::new(rx));
-
-    // Spawn worker threads
-    let num_workers = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
-    let workers: Vec<_> = (0..num_workers)
-        .map(|_| {
-            let rx = Arc::clone(&rx);
-            thread::spawn(move || {
-                loop {
-                    let page = rx.lock().unwrap().recv();
-                    match page {
-                        Ok(page) => {
-                            // Analyze the page
-                            let analysis = PageAnalysis::analyse_page(&page.revisions).unwrap();
-                            // Processing logic
-                        }
-                        Err(_) => break,
-                    }
-                }
-            })
-        })
-        .collect();
-
-    // Parse pages and send them to workers
-    while let Some(page) = parser.parse_page()? {
-        tx.send(page)?;
-    }
-    drop(tx); // Close the channel
-
-    // Wait for all workers to finish
-    for worker in workers {
-        worker.join().unwrap();
-    }
-
-    Ok(())
-}
-```
+The simplest approach is to feed parsed pages into a [`rayon`](https://docs.rs/rayon)
+parallel iterator, or into an `std::sync::mpsc` channel drained by a pool of worker
+threads. For a complete, production-grade reference — bounded queueing, progress
+reporting, and ordered output — see the bundled CLI in
+[`src/bin/wikiwho-cli.rs`](src/bin/wikiwho-cli.rs).
 
 ## Modules and API
 
@@ -190,7 +151,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Dependencies
 
-- **`compact_str`**: Used in the public API for efficient handling of mostly short strings, such as page titles and contributor names.
+The crate keeps a modest set of mandatory dependencies and pulls in the rest only when you
+enable the corresponding [feature](#features-and-configuration).
+
+**Always compiled:** `blake3`, `chrono`, `compact_str`, `imara-diff`, `quick-xml`, `rand`,
+`regex`, `rustc-hash`, `string-interner`, `thiserror`, `tracing`, and `yoke`. `compact_str`
+in particular appears in the public API for efficient handling of mostly short strings such
+as page titles and contributor names.
+
+**Optional (feature-gated):** `aho-corasick` + `memchr` (`optimized-str`),
+`unicode-case-mapping` (`optimized-lowercase`), `pyo3` (`python-diff`), `serde` +
+`serde_json` (`serde`), and `getopts` + `bzip2` + `flate2` + `zstd` (`cli`).
 
 ## Performance Considerations
 
@@ -200,6 +171,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 - **Diff Algorithm Choice**: By default, a faster diff algorithm is used. For exact results matching the original implementation, enable the `python-diff` feature and use `PageAnalysis::analyse_page_with_options` to select the Python diff algorithm.
 
 ## Features and Configuration
+
+`wikiwho` exposes six Cargo features. Only `optimized-str` is enabled by default
+(`default = ["optimized-str"]`):
+
+| Feature | Default | Description |
+| --- | :---: | --- |
+| `optimized-str` | ✅ | Faster tokenization and paragraph/sentence splitting via the Aho-Corasick algorithm and `memchr::memmem`. Produces identical results to the fallback implementation; disable only to trim dependencies. |
+| `optimized-lowercase` | | Faster non-ASCII lowercasing via the `unicode-case-mapping` crate. Requires both this feature *and* a runtime opt-in (`PageAnalysisOptions::optimize_non_ascii`). |
+| `python-diff` | | Use the original Python diff algorithm (via `pyo3`) for byte-exact parity with reference WikiWho. Much slower; intended for testing and validation. Also requires a runtime opt-in (`PageAnalysisOptions::use_python_diff`). |
+| `strict` | | Make the parser abort on malformed input instead of recovering and continuing. |
+| `serde` | | Derive `serde` `Serialize`/`Deserialize` for the public types. **Note:** the serialized `PageAnalysis` format changed in 0.3.0 and is *not* compatible with data produced by earlier versions. |
+| `cli` | | Build the `wikiwho-cli` binary for running analysis on dumps from the command line. Implies `serde`. |
+
+The sections below cover the runtime-relevant features in more detail.
 
 ### Diff Algorithm Selection
 


### PR DESCRIPTION
Closes #22. Builds on the #21 README restructure.

## Changes

- **Feature table.** Replaced the prose feature descriptions with a table covering all **six** features (`optimized-str`, `optimized-lowercase`, `python-diff`, `strict`, `serde`, `cli`), marking `optimized-str` as the lone default and noting the serde serialized-format incompatibility introduced in 0.3.0.
- **Dependencies section.** Replaced the `compact_str`-only blurb with an accurate inventory: the ~12 always-compiled deps vs. the optional feature-gated ones.
- **MSRV + default features.** Added "Requires Rust ≥ 1.94.1" and the default feature set right next to the install snippet.
- **Basic example.** Dropped the redundant owned-`Revision` lookup map (it consumed `page.revisions` into a clone-map) in favour of a borrowed `id -> &Contributor` map, and documented the anonymous-editor behaviour (`contributor.id` is `None`, `contributor.username` holds the IP).
- **Parallel example.** Trimmed the ~60-line hand-rolled `Arc<Mutex<Receiver>>` worker pool down to prose plus a `rayon` pointer and a reference to the bundled CLI.
- **Changelog.** Added one-line yank reasons for 0.3.2 (CI attestation step silently failed on a cargo 1.96 `.crate` path change) and 0.3.3 (released before immutable releases were enabled / with bad changelog links; superseded by 0.3.4).

## Note on `analysis.revisions_by_id`

The issue suggested rewriting the basic example to use `analysis.revisions_by_id`. That map yields `RevisionPointer`s, which (since 0.3.0) only expose the revision `id` — not the editor — so it can't supply the `contributor.username` the example prints. Editor metadata lives only on the parsed dump `Revision`s, so the example still builds a tiny id→contributor map, but now by borrowing instead of cloning whole revisions. The comment points readers at `analysis.revisions_by_id` for analysis-side per-revision data.

## Verification

- `cargo test --doc` passes (basic, dump, and full-dump examples compile).
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` passes.

https://claude.ai/code/session_015HNjBiaqQ8wcbJWDc1EQfR

---
_Generated by [Claude Code](https://claude.ai/code/session_015HNjBiaqQ8wcbJWDc1EQfR)_