### PR TITLE
ci: move changelog gate to its own label-reactive workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,37 @@
+name: changelog
+
+# Lightweight gate, split out from ci.yml on purpose. It listens to `labeled`/`unlabeled`
+# in addition to the usual PR events, so applying or removing the `skip-changelog` label
+# after a PR is opened re-evaluates the gate automatically — without re-running the full
+# CI suite. (A bare `pull_request:` trigger freezes the label list into the event payload
+# at open time, which is why a late `skip-changelog` label never used to take effect.)
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+# A label toggle supersedes any in-flight run for the same PR.
+concurrency:
+  group: changelog-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changelog:
+    name: changelog entry
+    # PRs must record their change under [Unreleased] in CHANGELOG.md. Skipped for Dependabot
+    # and for PRs carrying the `skip-changelog` label (CI/docs/refactors that don't warrant one).
+    # On a `labeled`/`unlabeled` event the payload's label list is current, so this re-evaluates
+    # correctly when the label is added or removed after the PR was opened.
+    if: github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0, lfs: false }
+      - name: Require a CHANGELOG.md update
+        run: |
+          git fetch --no-tags origin "$GITHUB_BASE_REF"
+          if git diff --name-only "origin/$GITHUB_BASE_REF...HEAD" | grep -qx 'CHANGELOG.md'; then
+            echo "CHANGELOG.md updated."
+          else
+            echo "::error::Add an entry under [Unreleased] in CHANGELOG.md, or apply the 'skip-changelog' label for changes that don't warrant one (CI, docs, refactors)."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,24 +135,9 @@ jobs:
         with:
           feature-group: all-features
 
-  changelog:
-    name: changelog entry
-    # PRs must record their change under [Unreleased] in CHANGELOG.md. Skipped for Dependabot
-    # and for PRs carrying the `skip-changelog` label (CI/docs/refactors that don't warrant one).
-    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 0, lfs: false }
-      - name: Require a CHANGELOG.md update
-        run: |
-          git fetch --no-tags origin "$GITHUB_BASE_REF"
-          if git diff --name-only "origin/$GITHUB_BASE_REF...HEAD" | grep -qx 'CHANGELOG.md'; then
-            echo "CHANGELOG.md updated."
-          else
-            echo "::error::Add an entry under [Unreleased] in CHANGELOG.md, or apply the 'skip-changelog' label for changes that don't warrant one (CI, docs, refactors)."
-            exit 1
-          fi
+  # The changelog gate lives in its own workflow (.github/workflows/changelog.yml) so that
+  # label changes (e.g. applying `skip-changelog`) re-trigger only that lightweight check,
+  # not this entire suite.
 
   # --- Headline: prove the Rust implementation matches the reference Python WikiWho ---
 


### PR DESCRIPTION
## Problem

`ci.yml`'s `pull_request:` trigger has no `types:`, so it defaults to `[opened, synchronize, reopened]`. The changelog gate read `github.event.pull_request.labels` — the label list **frozen into the event payload at trigger time**. So applying `skip-changelog` *after* opening a PR never took effect, and a plain re-run just replays the same label-less payload.

This surfaced in #27, where the only way to make the gate honor the label was to **close and reopen** the PR (a `reopened` event with a fresh payload).

## Fix (Option B)

Split the gate into its own lightweight workflow, `changelog.yml`, that additionally triggers on `labeled` / `unlabeled`. Adding or removing `skip-changelog` now re-fires **only this ~10s workflow** and re-evaluates the gate — the heavy `ci.yml` suite never reacts to label changes.

- `ci.yml`: `changelog` job removed (replaced by a pointer comment).
- `changelog.yml`: new; `pull_request: types: [opened, synchronize, reopened, labeled, unlabeled]`; same diff-based check and `skip-changelog` / Dependabot skips as before.
- Job name kept as **`changelog entry`** so the required-status-check context still matches branch protection.
- Distinct `concurrency` group (`changelog-…`) so it doesn't interfere with `ci.yml`'s.

## Why not the alternatives

- **Adding `labeled` to `ci.yml` directly** would re-run the *entire* suite (parity, coverage, gold-standard, semver) on every label toggle. Rejected.
- **A start-of-job `sleep`** to give a labeling window is a race, not a gate — it only catches labels added quickly and still needs a re-run for labels applied after review. Rejected.

## Live check

This PR is itself CI-only, so it carries `skip-changelog`. Expect the `changelog entry` check to **fail on the initial `opened` event** (no entry, label not yet applied) and then **pass once the label is added** (the `labeled` event re-runs `changelog.yml`) — which is exactly the behavior being fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)