### PR TITLE
docs(api): fill rustdoc gaps (entry points, module docs, internal surface)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Filled in rustdoc gaps across the public API: doc comments for `PageAnalysis::analyse_page_with_options` and `utils::iterate_revision_tokens`, module-level overviews for the `algorithm`, `dump_parser` and `optimized_str` modules plus a crate-layout map in the crate root, and per-field documentation for `dump_parser::Revision` (which fields the algorithm uses versus parser-only metadata, and safe defaults for constructing revisions by hand).
-- Hid internal, non-API items from the documentation with `#[doc(hidden)]`: the `PageAnalysis::{new, new_revision, new_paragraph, new_sentence, new_word}` constructors and the `RevisionSubstr` type alias. This is intentionally **non-breaking** — the items stay `pub` so existing code (and the integration-test crate, which relies on the constructors) keeps compiling, and `cargo-semver-checks` treats `#[doc(hidden)]` items as exempt, so no version bump is required. Tightening their visibility to `pub(crate)` was deliberately deferred because it would be a breaking change requiring a `0.x` minor bump.
+- **Breaking:** Marked internal, non-API items as `#[doc(hidden)]`, removing them from the documented public API: the `PageAnalysis::{new, new_revision, new_paragraph, new_sentence, new_word}` constructors and the `RevisionSubstr` type alias. These are implementation details (used internally by `analyse_page` and by the test suite) and remain `pub`, so code that calls them still compiles; however, `cargo-semver-checks` classifies doc-hiding an inherent method as a breaking change, hence the `0.4.0` minor bump.
 
 ## [0.3.4] - 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Filled in rustdoc gaps across the public API: doc comments for `PageAnalysis::analyse_page_with_options` and `utils::iterate_revision_tokens`, module-level overviews for the `algorithm`, `dump_parser` and `optimized_str` modules plus a crate-layout map in the crate root, and per-field documentation for `dump_parser::Revision` (which fields the algorithm uses versus parser-only metadata, and safe defaults for constructing revisions by hand).
+- Hid internal, non-API items from the documentation with `#[doc(hidden)]`: the `PageAnalysis::{new, new_revision, new_paragraph, new_sentence, new_word}` constructors and the `RevisionSubstr` type alias. This is intentionally **non-breaking** — the items stay `pub` so existing code (and the integration-test crate, which relies on the constructors) keeps compiling, and `cargo-semver-checks` treats `#[doc(hidden)]` items as exempt, so no version bump is required. Tightening their visibility to `pub(crate)` was deliberately deferred because it would be a breaking change requiring a `0.x` minor bump.
+
 ## [0.3.4] - 2026-06-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "wikiwho"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "aho-corasick",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wikiwho"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MPL-2.0 AND MIT"

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -1,4 +1,26 @@
 // SPDX-License-Identifier: MIT AND MPL-2.0
+//! Token-level authorship analysis — the WikiWho algorithm.
+//!
+//! This module turns an ordered sequence of [`Revision`]s
+//! into a [`PageAnalysis`]: a graph of paragraphs, sentences and tokens (≈ words)
+//! that records, for every token still present in a revision, the revision in
+//! which it was first introduced (its *origin*) together with its add/delete
+//! history across the page's lifetime.
+//!
+//! # Entry points
+//!
+//! - [`PageAnalysis::analyse_page`] — analyse a page with default options.
+//! - [`PageAnalysis::analyse_page_with_options`] — same, but select algorithm
+//!   behavior via [`PageAnalysisOptions`] (e.g. the `python-diff` diff algorithm or
+//!   optimized non-ASCII lowercasing).
+//!
+//! Consume the result with
+//! [`iterate_revision_tokens`](crate::utils::iterate_revision_tokens), which walks
+//! the tokens of a revision in reading order.
+//!
+//! Revisions must be supplied in chronological order (oldest first): the algorithm
+//! relies on the order of the input sequence, not on the `timestamp` field of each
+//! [`Revision`].
 mod types;
 use std::{
     borrow::{Borrow, Cow},
@@ -395,6 +417,24 @@ impl PageAnalysis {
         Self::analyse_page_with_options(xml_revisions, PageAnalysisOptions::default())
     }
 
+    /// Like [`analyse_page`](Self::analyse_page), but lets you select algorithm
+    /// behavior via [`PageAnalysisOptions`].
+    ///
+    /// Use this entry point when you need non-default behavior, such as the
+    /// Python-compatible diff algorithm (`python-diff` feature) or the optimized
+    /// non-ASCII lowercasing path (`optimized-lowercase` feature). See
+    /// [`PageAnalysisOptions`] for the full list of options;
+    /// [`analyse_page`](Self::analyse_page) is exactly this function called with
+    /// [`PageAnalysisOptions::default`].
+    ///
+    /// As with [`analyse_page`](Self::analyse_page), `xml_revisions` must be in
+    /// chronological order (oldest first), as returned by
+    /// [`DumpParser::parse_page`](crate::dump_parser::DumpParser::parse_page).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnalysisError::NoValidRevisions`] if every revision in the input
+    /// is classified as spam or has empty/deleted text.
     pub fn analyse_page_with_options<I, R>(
         xml_revisions: I,
         analysis_options: PageAnalysisOptions,

--- a/src/algorithm/types.rs
+++ b/src/algorithm/types.rs
@@ -182,6 +182,7 @@ impl<T> MaybeVec<T> {
     }
 }
 
+#[doc(hidden)] // internal type alias; not part of the supported public API
 pub type RevisionSubstr = Yoke<Cow<'static, str>, Arc<String>>;
 
 #[derive(Clone)]
@@ -370,6 +371,11 @@ pub struct PageAnalysis {
 impl PageAnalysis {
     /// Creates a PageAnalysis initialized with the given revision as `current_revision`.
     /// For normal use, prefer `analyse_page()`.
+    // Hidden from the public API: a low-level constructor used internally by
+    // `analyse_page` and by the integration tests. Kept `pub` (not `pub(crate)`)
+    // so the integration test crate can still build it; `#[doc(hidden)]` is the
+    // non-breaking way to keep it out of the documented surface.
+    #[doc(hidden)]
     pub fn new(initial_revision: (RevisionAnalysis, RevisionImmutables)) -> Self {
         let arc = Arc::new(initial_revision.1);
         let initial_revision_ptr = RevisionPointer(0, arc.clone());
@@ -392,6 +398,7 @@ impl PageAnalysis {
         }
     }
 
+    #[doc(hidden)] // internal constructor (see `new`)
     pub fn new_revision(&mut self, revision_data: RevisionImmutables) -> RevisionPointer {
         let arc = Arc::new(revision_data);
         let revision_pointer = RevisionPointer(self.revisions.len(), arc.clone());
@@ -400,6 +407,7 @@ impl PageAnalysis {
         revision_pointer
     }
 
+    #[doc(hidden)] // internal constructor (see `new`)
     pub fn new_paragraph(&mut self, paragraph_data: ParagraphImmutables) -> ParagraphPointer {
         let arc = Arc::new(paragraph_data);
         let paragraph_pointer = ParagraphPointer(self.paragraphs.len(), arc.clone());
@@ -408,6 +416,7 @@ impl PageAnalysis {
         paragraph_pointer
     }
 
+    #[doc(hidden)] // internal constructor (see `new`)
     pub fn new_sentence(&mut self, sentence_data: SentenceImmutables) -> SentencePointer {
         let arc = Arc::new(sentence_data);
         let sentence_pointer = SentencePointer(self.sentences.len(), arc.clone());
@@ -416,6 +425,7 @@ impl PageAnalysis {
         sentence_pointer
     }
 
+    #[doc(hidden)] // internal constructor (see `new`)
     pub fn new_word(
         &mut self,
         word_data: WordImmutables,

--- a/src/algorithm/types.rs
+++ b/src/algorithm/types.rs
@@ -373,8 +373,9 @@ impl PageAnalysis {
     /// For normal use, prefer `analyse_page()`.
     // Hidden from the public API: a low-level constructor used internally by
     // `analyse_page` and by the integration tests. Kept `pub` (not `pub(crate)`)
-    // so the integration test crate can still build it; `#[doc(hidden)]` is the
-    // non-breaking way to keep it out of the documented surface.
+    // so the integration test crate can still build it; `#[doc(hidden)]` removes
+    // it from the documented surface (classified as breaking by
+    // cargo-semver-checks, hence the 0.4.0 bump).
     #[doc(hidden)]
     pub fn new(initial_revision: (RevisionAnalysis, RevisionImmutables)) -> Self {
         let arc = Arc::new(initial_revision.1);

--- a/src/dump_parser/mod.rs
+++ b/src/dump_parser/mod.rs
@@ -1,4 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
+//! Streaming parser for Wikimedia XML dumps.
+//!
+//! [`DumpParser`] reads a `pages-meta-history` XML dump from any
+//! [`BufRead`] and yields one [`Page`] at a time via
+//! [`DumpParser::parse_page`], so memory use stays roughly constant regardless of
+//! dump size. Each [`Page`] carries its [`Revision`]s in the dump's order (oldest
+//! first) — exactly the order
+//! [`PageAnalysis::analyse_page`](crate::algorithm::PageAnalysis::analyse_page)
+//! expects.
+//!
+//! The parser targets Wikimedia dump format 0.11. By default it is lenient,
+//! logging and recovering from malformed input; enable the `strict` feature to
+//! make it abort on the first error instead. The parsed data model lives in this
+//! module's re-exports: [`Page`], [`Revision`], [`Contributor`], [`Text`] and
+//! [`SiteInfo`].
 mod types;
 pub use types::*;
 

--- a/src/dump_parser/types.rs
+++ b/src/dump_parser/types.rs
@@ -72,16 +72,67 @@ impl Debug for Sha1Hash {
 }
 
 // apparently `restricted` is never set in mwxml (https://github.com/mediawiki-utilities/python-mwxml/blob/2b477be6aa9794064d03b5be38c7759d1570488b/mwxml/iteration/revision.py#L80)
+/// A single revision of a [`Page`].
+///
+/// When parsing a dump these are produced by the
+/// [parser](crate::dump_parser::DumpParser); you can also construct them by hand to
+/// feed the [algorithm](crate::algorithm) from a non-MediaWiki source.
+///
+/// The algorithm only reads a subset of these fields: [`text`](Self::text),
+/// [`sha1`](Self::sha1), [`comment`](Self::comment) and [`minor`](Self::minor)
+/// affect the analysis, and [`id`](Self::id) is carried through so results can be
+/// mapped back to the originating revision. [`timestamp`](Self::timestamp) and
+/// [`contributor`](Self::contributor) are preserved for the caller's own
+/// bookkeeping but are *not* used by the algorithm — in particular, chronological
+/// ordering is taken from the order in which revisions are passed to
+/// [`PageAnalysis::analyse_page`](crate::algorithm::PageAnalysis::analyse_page),
+/// not from `timestamp`. See the per-field notes for safe defaults when
+/// constructing manually.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Revision {
+    /// Unique identifier of the revision.
+    ///
+    /// Carried through analysis unchanged: the origin of every token is reported
+    /// as a [`RevisionPointer`](crate::algorithm::RevisionPointer) whose
+    /// [`id`](crate::algorithm::RevisionImmutables::id) equals this value, so it
+    /// must be unique per revision if you want to map tokens back to their source.
     pub id: i32,
+    /// Timestamp of the revision.
+    ///
+    /// Parser metadata only; not used by the algorithm (which derives order from
+    /// the input sequence). When constructing manually any value works, e.g.
+    /// `chrono::Utc::now()`.
     pub timestamp: chrono::DateTime<chrono::Utc>,
+    /// Author of the revision (aka. user).
+    ///
+    /// Parser metadata only; not used by the algorithm. To recover authorship, map
+    /// a token's origin revision [`id`](Self::id) back to your own data. When
+    /// constructing manually, a default/empty [`Contributor`] is fine.
     // aka. user
     pub contributor: Contributor,
+    /// Wikitext content of the revision, or [`Text::Deleted`] for revisions whose
+    /// text was removed.
+    ///
+    /// This is the content the algorithm analyses; it is required. Revisions with
+    /// [`Text::Deleted`] are skipped.
     pub text: Text,
+    /// Optional precomputed SHA-1 of the revision text, as found in the dump.
+    ///
+    /// Used as a fast content-equality hash during spam/vandalism detection. When
+    /// absent, the algorithm hashes the text itself (BLAKE3), so `None` is a safe
+    /// default for manual construction.
     pub sha1: Option<Sha1Hash>,
+    /// Optional edit summary/comment.
+    ///
+    /// Together with [`minor`](Self::minor) this tunes one spam-detection
+    /// heuristic (a minor edit that carries a comment skips the deletion check).
+    /// `None` is a safe default.
     pub comment: Option<CompactString>,
+    /// Whether the revision was flagged as a minor edit.
+    ///
+    /// See [`comment`](Self::comment) for how it is used; `false` is a safe
+    /// default.
     pub minor: bool,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,26 @@
 //! ```rust,ignore
 //! let origin_revision = &analysis.words[word_pointer.unique_id()].origin_revision;
 //! ```
+//!
+//! ## Crate layout
+//!
+//! At a high level the crate is a pipeline of three stages, each in its own module:
+//!
+//! - **Parse** — [`dump_parser`]: a streaming parser for Wikimedia XML dumps that
+//!   yields [`Page`](dump_parser::Page) / [`Revision`](dump_parser::Revision)
+//!   values one page at a time.
+//! - **Analyse** — [`algorithm`]: the WikiWho authorship algorithm. The entry
+//!   point is [`PageAnalysis::analyse_page`](algorithm::PageAnalysis::analyse_page)
+//!   (or
+//!   [`analyse_page_with_options`](algorithm::PageAnalysis::analyse_page_with_options)
+//!   for non-default options).
+//! - **Consume** — [`utils`]: helpers for reading results, notably
+//!   [`iterate_revision_tokens`](utils::iterate_revision_tokens).
+//!
+//! Diffing — the heart of the algorithm — lives in two internal modules that are
+//! not part of the public API: `difflib` (a clean-room Ratcliff/Obershelp matcher
+//! mirroring Python's `difflib`) and `optimized_str` (fast string splitting and
+//! lowercasing).
 
 pub mod algorithm;
 pub(crate) mod difflib;

--- a/src/optimized_str.rs
+++ b/src/optimized_str.rs
@@ -1,4 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
+//! Fast, allocation-light string processing used by the analysis pipeline.
+//!
+//! This module provides optimized replacements for the text-splitting routines in
+//! [`utils`](crate::utils): paragraph, sentence and token splitting built on
+//! Aho-Corasick and `memchr`-based scanning, designed to avoid copying the input
+//! wherever a borrowed substring will do.
+//!
+//! It is an internal implementation detail: it is gated behind the `optimized-str`
+//! feature and hidden from the public API (only exposed so it can be benchmarked).
+//! Call the stable wrappers in [`utils`](crate::utils) instead, which dispatch to
+//! these implementations when the feature is enabled.
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder, PatternID};
 use memchr::memmem;
 use regex::Regex;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -313,6 +313,21 @@ pub fn trim_in_place(input: Cow<'_, str>) -> Cow<'_, str> {
     }
 }
 
+/// Iterates over the tokens (≈ words) present in a revision, in reading order.
+///
+/// Given a [`RevisionPointer`] into `analysis`, this yields the tokens that are
+/// *present* in that revision — in paragraph → sentence → word order, i.e. the
+/// order in which they appear in the article text. Tokens that had been deleted by
+/// this revision are not part of its structure and are therefore not yielded; to
+/// inspect deletions, look at the add/delete history on the individual
+/// [`WordAnalysis`](crate::algorithm::WordAnalysis) instead.
+///
+/// This is the primary way to consume analysis results. Pass
+/// [`PageAnalysis::current_revision`] to walk the latest (non-spam) revision, or
+/// any [`RevisionPointer`] from [`PageAnalysis::ordered_revisions`] for a
+/// historical one, then index into `analysis` with each yielded [`WordPointer`]
+/// (e.g. `&analysis[word]`) to read its authorship data, such as the
+/// [`origin_revision`](crate::algorithm::WordAnalysis::origin_revision).
 pub fn iterate_revision_tokens<'a>(
     analysis: &'a PageAnalysis,
     revision: &RevisionPointer,


### PR DESCRIPTION
Closes #25.

Fills the rustdoc gaps surfaced by the multi-persona README review.

## Changes

- **`PageAnalysis::analyse_page_with_options`** — now documented, mirroring `analyse_page` (input contract, chronological-order requirement, `# Errors`) and explaining the options it unlocks (`python-diff`, optimized non-ASCII lowercasing).
- **`utils::iterate_revision_tokens`** — documented as the primary output-consumption API: yields the tokens *present* in a revision in paragraph → sentence → word order, takes a `RevisionPointer`, and excludes tokens deleted by that revision.
- **Module-level `//!` headers** for `algorithm`, `dump_parser`, and `optimized_str` (`difflib` already had a thorough one), plus a **crate-layout map** in the crate root that points contributors at parser (`dump_parser`) → algorithm (`algorithm`) → diff (`difflib` / `optimized_str`) code.
- **`Revision` field docs** — every field documented, calling out which the algorithm reads (`text`, `sha1`, `comment`, `minor`, and `id` carried through to results) versus parser-only metadata (`timestamp`, `contributor`), with safe defaults for constructing revisions by hand.
- **Tidied the internal-but-`pub` surface** with `#[doc(hidden)]`: `PageAnalysis::{new, new_revision, new_paragraph, new_sentence, new_word}` and the (unused) `RevisionSubstr` type alias.
- **CHANGELOG**: added a single consolidated `### Documentation` entry summarizing the whole documentation marathon (PRs #27–#33), since most of those PRs used `skip-changelog`.

## ⚠️ Semver decision → version bump to 0.4.0

Chose `#[doc(hidden)]` over `pub(crate)` for the internal constructors. The items stay `pub`, so existing dependents — and importantly the integration-test crate in `tests/common/mod.rs`, which constructs `PageAnalysis` directly — keep compiling.

**Correction to the original plan:** the issue assumed `#[doc(hidden)]` would be non-breaking, but the CI `semver` gate proved otherwise. `cargo-semver-checks` (0.48.0) classifies doc-hiding a public **inherent method** as a major/breaking change (lint `inherent_method_now_doc_hidden`) — it fired on the five `PageAnalysis::new*` constructors. (The `RevisionSubstr` type alias was *not* flagged.)

Per maintainer decision, we kept the items hidden and **bumped `0.3.4` → `0.4.0`** (a `0.x` minor bump signals breaking), which is exactly what the semver gate requires. `Cargo.toml`, the `CHANGELOG.md` `[Unreleased]` entry (now marked **Breaking**), and the in-code comments were all updated to reflect this. Tightening visibility to `pub(crate)` remains a possible follow-up but is unnecessary now.

This branch has also been synced with `main` (it had fallen ~18 commits behind), resolving a `CHANGELOG.md` conflict so the entries from the rest of the marathon are preserved.

## Verification (CI green on the merge commit)

- `semver (all features)` — **passes** with the `0.4.0` bump.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — passes (matches CI's `doc` job; fixed two `redundant_explicit_link` warnings along the way).
- `cargo check --tests --features serde,cli,strict,optimized-str,optimized-lowercase` — passes (confirms the `#[doc(hidden)]` constructors remain reachable from the integration-test crate).
- `cargo test --doc --features serde` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxMt4x4aDGrRzzftHSWHdZ