### PR TITLE
docs: fix contributor test-harness footguns; add SKIP notices for empty suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A plain `cargo test` now emits visible `SKIP:` notices (via a new `skipped_suites` test target) when a feature-gated integration suite (`algorithm_exact_tests`, `algorithm_statistic_tests`, `utils_comparisons`) compiles empty, instead of silently reporting `running 0 tests`. Contributor docs gained matching guidance: the canonical test command, Git LFS / Python prerequisites, the editable VCS `requirements.txt`, `.venv` standardization, and a "Reproducing the CI gates" checklist. Several documented test commands that compiled feature-gated suites empty were corrected to include the required `serde`/`python-diff` features.
+
 ## [0.3.4] - 2026-06-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- A plain `cargo test` now emits visible `SKIP:` notices (via a new `skipped_suites` test target) when a feature-gated integration suite (`algorithm_exact_tests`, `algorithm_statistic_tests`, `utils_comparisons`) compiles empty, instead of silently reporting `running 0 tests`. Contributor docs gained matching guidance: the canonical test command, Git LFS / Python prerequisites, the editable VCS `requirements.txt`, `.venv` standardization, and a "Reproducing the CI gates" checklist. Several documented test commands that compiled feature-gated suites empty were corrected to include the required `serde`/`python-diff` features.
-
 ## [0.3.4] - 2026-06-15
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,17 @@ By submitting a contribution, you agree that your code will be licensed under th
 
 ## Getting Started
 
-- Fork the repository: [wikiwho_rs GitHub](https://github.com/Schuwi/wikiwho_rs)
+### Prerequisites
+
+Install these **before cloning**:
+
+- **[Git LFS](https://git-lfs.com/).** The committed test data — the representative dump subset and the gold-standard article cache — lives in Git LFS (`.gitattributes` routes every `*.zst` through it). Run `git lfs install` once, then clone. If you skip this, the `*.zst` files arrive as tiny text pointer files and tests fail with confusing decode errors; recover with `git lfs install && git lfs pull`.
+- **A Rust toolchain** via [rustup](https://rustup.rs/). Everyday work uses `stable`. The MSRV is **1.94.1** (`rust-version` in `Cargo.toml`); add it with `rustup toolchain install 1.94.1` if you want to reproduce the MSRV gate locally (see [Reproducing the CI gates](#reproducing-the-ci-gates)).
+- **Python 3** — only needed for the Rust-vs-Python parity tests (see [Development Setup](#development-setup)).
+
+### Workflow
+
+- Fork the repository ([wikiwho_rs on GitHub](https://github.com/Schuwi/wikiwho_rs)) and clone your fork.
 - Create a new branch for your feature or bug fix.
 - Add an entry under `## [Unreleased]` in [`CHANGELOG.md`](CHANGELOG.md) (Keep a Changelog format). CI enforces this; for changes that don't warrant an entry (CI, docs, refactors) a maintainer can apply the `skip-changelog` label.
 - If your change alters the public API in a breaking way, bump `version` in `Cargo.toml` (for `0.x`, the minor field) — the `semver` CI job checks this.
@@ -20,25 +30,56 @@ By submitting a contribution, you agree that your code will be licensed under th
 
 ## Development Setup
 
-The exact comparison tests call into the original Python WikiWho implementation to validate results, so a Python virtual environment must be active when running them. Without it, tests will fail with cryptic Python/pyo3 errors.
+Most of the suite is pure Rust and needs no setup — see [Running the tests](#running-the-tests). The Rust-vs-Python comparison tests, however, call into the original WikiWho implementation to validate results, so a Python virtual environment with that implementation installed must be active when running them. Without it they fail with cryptic Python/pyo3 errors.
 
 ```sh
-python -m venv venv
-source venv/bin/activate   # on Windows: venv\Scripts\activate
+python -m venv .venv
+source .venv/bin/activate   # on Windows: .venv\Scripts\activate
 pip install -r requirements.txt
-cargo test --features python-diff
+cargo test --features python-diff,serde
 ```
+
+> **`requirements.txt` is not an ordinary pip install.** It pins an *editable VCS checkout* of a [WikiWho fork](https://github.com/Schuwi/WikiWho) (forked to keep the `value` fields of sentence and paragraph objects for exact-equivalence tests):
+>
+> ```text
+> -e git+https://github.com/Schuwi/WikiWho.git@<commit>#egg=WikiWho
+> ```
+>
+> So `pip install` needs **`git` and network access** and will clone and build the fork — slower than a plain wheel download. This is exactly what CI does (`.venv` + `requirements.txt`).
 
 To control where large temporary IPC files are written, set `TMPDIR` before running:
 
 ```sh
-TMPDIR=/path/with/space cargo test --features python-diff
+TMPDIR=/path/with/space cargo test --features python-diff,serde
 ```
+
+## Running the tests
+
+A bare `cargo test` is misleading here. The integration suites are **feature-gated at the file level**, so with the default features they compile to empty binaries that print `running 0 tests` and still exit `0` — a run that tested *nothing* looks exactly like a run that tested everything. Two things guard against that:
+
+- **Run the canonical pure-Rust command**, the same one CI's `test` job uses (`.github/workflows/ci.yml`). This superset of the Python-free features exercises every unit and doc test — both the optimized and naive string paths, serde round-trips, and so on:
+
+  ```sh
+  cargo test --lib --features serde,cli,strict,optimized-str,optimized-lowercase
+  cargo test --doc --features serde
+  ```
+
+- **Watch for `SKIP:` notices.** When a feature-gated suite compiles empty, the `skipped_suites` test binary reports a named, passing test that names the missing flag — e.g. `skipped_algorithm_exact_tests_enable_python_diff_and_serde`. Add `-- --nocapture` to see the full `SKIP:` line.
+
+To actually run the feature-gated suites (the `python-diff` ones also need the Python venv from [Development Setup](#development-setup)):
+
+| Suite | Needs | Command |
+|---|---|---|
+| `algorithm_exact_tests` (Rust-vs-Python parity) | `python-diff`, `serde` | `cargo test --features python-diff,serde --test algorithm_exact_tests` |
+| `utils_comparisons` (tokenizer parity) | `python-diff` | `cargo test --features python-diff --test utils_comparisons` |
+| `algorithm_statistic_tests` (gold-standard accuracy) | `serde` (+ data) | see [Testing and Validation](#testing-and-validation) |
+
+> `tests/parser_tests.rs` is intentionally empty for now (tracked in [#6](https://github.com/Schuwi/wikiwho_rs/issues/6)); it likewise reports `running 0 tests`.
 
 ## Testing and Validation
 
-- **Exact comparison tests** (`algorithm_exact_tests.rs`): Compare the Rust implementation's results against the original Python WikiWho, token by token. These require the `python-diff` feature so that both implementations use the same diff algorithm. Run them with `cargo test --features python-diff`.
-- **Statistical comparison tests** (`algorithm_statistic_tests.rs`): Ignored by default and require local benchmark data. Fetch the archived partial gold standard with `python3 tools/fetch_gold_standard.py`, place current Wikimedia dump shards into `dev-data/extra-dumps/`, then run with `cargo test gold_standard_precision_rust -- --ignored` or `cargo test --features python-diff divergence_rate_gold_standard_articles -- --ignored`. See `dev-data/README.md` for details. CI runs these against a committed cache of gold-standard article histories (the pure-Rust precision test on every PR; the python-diff baselines on push to `main`).
+- **Exact comparison tests** (`algorithm_exact_tests.rs`): Compare the Rust implementation's results against the original Python WikiWho, token by token. These require the `python-diff` and `serde` features (`python-diff` so both implementations use the same diff algorithm; `serde` for the fixture cache), so the whole suite is gated behind both. Run them with `cargo test --features python-diff,serde --test algorithm_exact_tests` (with the Python venv active; see [Development Setup](#development-setup)).
+- **Statistical comparison tests** (`algorithm_statistic_tests.rs`): Gated behind `serde`, ignored by default, and require local benchmark data. Fetch the archived partial gold standard with `python3 tools/fetch_gold_standard.py`, place current Wikimedia dump shards into `dev-data/extra-dumps/`, then run with `cargo test --features serde --test algorithm_statistic_tests -- --ignored gold_standard_precision_rust` (pure Rust) or `cargo test --features python-diff,serde --test algorithm_statistic_tests -- --ignored divergence_rate_gold_standard_articles` (vs. Python). See [`dev-data/README.md`](dev-data/README.md) for details. CI runs these against a committed cache of gold-standard article histories (the pure-Rust precision test on every PR; the python-diff baselines on push to `main`).
 - **Temporary files**: Some tests use temporary files for IPC coordination between Rust and Python. These files can be large depending on the input dump. Their location follows `std::env::temp_dir()`, which can be controlled by setting the `TMPDIR` environment variable.
 - **Test dump location**: Real-page tests read a reference dump; set `WIKIWHO_TEST_DUMP=/path/to/dump.xml.zst` to override the default path. If the dump is absent, those tests skip (with a `SKIP:` notice) instead of failing.
 - **Community Feedback**: Seeking input from users testing with different languages and datasets.
@@ -56,6 +97,40 @@ Test data:
 
 - The representative subset (`dewiktionary-20240901-ci-subset.xml.zst`, ~900 KB) is committed via Git LFS, so contributors and CI get it on clone — no download needed. Regenerate it from a full dump with `python3 tools/make_ci_subset.py`.
 - The full 808 MB dump lives in the [`Schuwi/wikiwho-data`](https://github.com/Schuwi/wikiwho-data) release. Fetch it (checksum-verified) with `python3 tools/fetch_test_data.py --which full`.
+
+### Reproducing the CI gates
+
+Before pushing, you can reproduce every blocking PR gate locally. Each maps to a job in `.github/workflows/ci.yml`:
+
+- **Format** (`fmt`): `cargo fmt --all --check`
+- **Lints** (`clippy`) — run the same feature combinations CI does, each with `-D warnings`:
+
+  ```sh
+  for f in "--no-default-features" "" "--features serde" "--features cli" \
+           "--features serde,cli,strict,optimized-str,optimized-lowercase"; do
+    cargo clippy --all-targets $f -- -D warnings
+  done
+  ```
+
+- **Tests** (`test`): the canonical command from [Running the tests](#running-the-tests).
+- **MSRV** (`msrv`) — there is deliberately no `rust-toolchain.toml` (it would override the `stable` toolchain CI's other jobs use), so pass the pinned toolchain explicitly:
+
+  ```sh
+  rustup toolchain install 1.94.1   # once
+  cargo +1.94.1 check --all-features
+  ```
+
+- **Docs** (`doc`): `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
+- **SemVer** (`semver`) — a breaking public-API change must bump `version` in `Cargo.toml` (the minor field, for `0.x`):
+
+  ```sh
+  cargo install cargo-semver-checks   # once
+  cargo semver-checks --all-features
+  ```
+
+- **Changelog** (`changelog`): the gate just greps the PR diff for a change to `CHANGELOG.md` — any edit under `## [Unreleased]` satisfies it (or a maintainer applies the `skip-changelog` label). It does **not** validate the content.
+
+The headline parity and gold-standard jobs additionally need the Python venv and/or the LFS data; see [Development Setup](#development-setup) and [Running the tests](#running-the-tests).
 
 ## Project Status and Support
 

--- a/dev-data/README.md
+++ b/dev-data/README.md
@@ -106,15 +106,17 @@ Wikimedia text dumps are generally reusable under CC BY-SA 4.0 and GFDL, with at
 
 ## Running
 
+These tests live in `algorithm_statistic_tests`, which is gated behind the `serde` feature; without it the suite compiles empty and the commands below run nothing.
+
 Pure Rust precision:
 
 ```sh
-cargo test gold_standard_precision_rust -- --ignored
+cargo test --features serde --test algorithm_statistic_tests -- --ignored gold_standard_precision_rust
 ```
 
-Python baseline and divergence checks:
+Python baseline and divergence checks (need the Python venv from `CONTRIBUTING.md`):
 
 ```sh
-cargo test --features python-diff gold_standard_precision_python_diff -- --ignored
-cargo test --features python-diff divergence_rate_gold_standard_articles -- --ignored
+cargo test --features python-diff,serde --test algorithm_statistic_tests -- --ignored gold_standard_precision_python_diff
+cargo test --features python-diff,serde --test algorithm_statistic_tests -- --ignored divergence_rate_gold_standard_articles
 ```

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -1,1 +1,7 @@
-
+// SPDX-License-Identifier: MPL-2.0
+//! Parser integration tests.
+//!
+//! Intentionally empty for now — implementing these is tracked in
+//! <https://github.com/Schuwi/wikiwho_rs/issues/6> (e.g. parsing the full bundled
+//! Wiktionary dump in `strict` mode). A plain `cargo test` reports this binary as
+//! `running 0 tests`; that is expected until the suite is populated or removed there.

--- a/tests/skipped_suites.rs
+++ b/tests/skipped_suites.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Visible "this suite was skipped" notices for the feature-gated integration tests.
+//!
+//! `algorithm_exact_tests`, `algorithm_statistic_tests`, and `utils_comparisons`
+//! are gated behind cargo features at the *file* level (e.g.
+//! `#![cfg(all(feature = "python-diff", feature = "serde"))]`). Without those features
+//! each one compiles to an empty test binary that prints `running 0 tests` — which is
+//! indistinguishable from a passing run, and has fooled contributors into thinking a
+//! plain `cargo test` exercised the Rust-vs-Python parity suites when it actually ran
+//! nothing.
+//!
+//! Each test below is compiled *only* when its suite is gated out, so a plain
+//! `cargo test` surfaces a named, passing test that says exactly which features to
+//! enable. The test name shows in libtest's default output; run with `--nocapture` for
+//! the full `SKIP:` line. See `CONTRIBUTING.md` → "Running the tests".
+
+/// `tests/algorithm_exact_tests.rs` — token-level Rust-vs-Python parity.
+/// Needs `python-diff` (same diff algorithm as the reference) and `serde`.
+#[cfg(not(all(feature = "python-diff", feature = "serde")))]
+#[test]
+fn skipped_algorithm_exact_tests_enable_python_diff_and_serde() {
+    eprintln!(
+        "SKIP: algorithm_exact_tests compiled empty — run with \
+         `--features python-diff,serde` to check Rust-vs-Python parity (see CONTRIBUTING.md)."
+    );
+}
+
+/// `tests/algorithm_statistic_tests.rs` — gold-standard accuracy (uses the serde JSON cache).
+#[cfg(not(feature = "serde"))]
+#[test]
+fn skipped_algorithm_statistic_tests_enable_serde() {
+    eprintln!(
+        "SKIP: algorithm_statistic_tests compiled empty — run with `--features serde` \
+         to check gold-standard accuracy (see CONTRIBUTING.md)."
+    );
+}
+
+/// `tests/utils_comparisons.rs` — Rust-vs-Python tokenizer/splitter parity (proptest).
+#[cfg(not(feature = "python-diff"))]
+#[test]
+fn skipped_utils_comparisons_enable_python_diff() {
+    eprintln!(
+        "SKIP: utils_comparisons compiled empty — run with `--features python-diff` \
+         to check Rust-vs-Python tokenizer parity (see CONTRIBUTING.md)."
+    );
+}


### PR DESCRIPTION
Closes #26.

Addresses the returning-contributor onboarding footguns from the multi-persona README review. The headline behavioral fix: a green `cargo test` could silently run **zero** integration tests, because `algorithm_exact_tests`, `algorithm_statistic_tests`, and `utils_comparisons` are feature-gated at the file level — without the right features they compile to empty binaries that print `running 0 tests` and exit `0`.

## Checklist coverage

- [x] **Empty-suite footgun.** Documented the canonical command (`cargo test --lib --features serde,cli,strict,optimized-str,optimized-lowercase`, mirroring `ci.yml`) **and** added `tests/skipped_suites.rs` — a tiny test target that emits a named, passing `SKIP` test (visible in default `cargo test` output, e.g. `skipped_algorithm_exact_tests_enable_python_diff_and_serde`) whenever a gated suite compiles empty. `--nocapture` shows the full `SKIP:` line.
- [x] **`venv` → `.venv`.** Standardized `CONTRIBUTING.md` on `.venv` (CI already used `.venv` in `ci.yml`/`fuzz.yml`/`heavy.yml`; `.gitignore` already ignores it).
- [x] **`requirements.txt` is a Git-fork VCS install.** Documented that it pins an editable `git+https://…` checkout of the WikiWho fork, so `pip install` needs **git + network** and clones/builds the fork.
- [x] **MSRV reproducibility.** Documented `rustup toolchain install 1.94.1` + `cargo +1.94.1 check --all-features` in the new "Reproducing the CI gates" checklist. **See note below** re: `rust-toolchain.toml`.
- [x] **LFS prerequisite.** Added an "install Git LFS before cloning" line to a new Prerequisites section.
- [x] **"Reproduce CI locally" checklist.** New section mapping each blocking job to a local command: clippy feature-combos, `cargo +1.94.1 check --all-features`, `cargo install cargo-semver-checks && cargo semver-checks --all-features`, and a note that the changelog gate just greps for a `CHANGELOG.md` diff.
- [x] **`parser_tests.rs` (#6).** Cross-linked the intentionally-empty file to #6 (file comment + a note in CONTRIBUTING) rather than duplicating.

## Bonus fix found along the way

Several **documented** test commands themselves fed the footgun: the exact-comparison suite is gated on `all(python-diff, serde)` but the docs said `cargo test --features python-diff` (no `serde` → compiles empty), and the statistical suite needs `serde` but the docs omitted it. Corrected in `CONTRIBUTING.md` and `dev-data/README.md` to match CI.

## ⚠️ One decision to confirm: no `rust-toolchain.toml`

The issue offered "Add `rust-toolchain.toml` pinning 1.94.1 **(or document `+1.94.1`)**". I went with **documenting `+1.94.1`** rather than committing a repo-wide toolchain file, because a `rust-toolchain.toml` at the root would:

- override the `stable` toolchain that CI's `fmt`/`clippy`/`test`/`doc`/etc. jobs select via `dtolnay/rust-toolchain@stable` (toolchain files outrank `rustup default`), and in particular break the clippy job, which installs clippy only for `stable`; and
- force **all** local development onto the MSRV instead of stable.

If you'd prefer the committed file anyway (it's a legitimate "build on MSRV by default" choice), say so and I'll add it **and** adjust CI to pin its toolchains explicitly so the stable jobs keep working.

## Note on the changelog entry

This is docs + test-tooling, i.e. exactly the `skip-changelog` category — but I can't apply the label, so I added a short `[Unreleased]` entry to keep the `changelog` gate green. Feel free to drop it and apply `skip-changelog` instead.

## Test plan

- `cargo fmt --all --check` ✅
- `cargo clippy --all-targets --no-default-features -- -D warnings` ✅
- `cargo clippy --all-targets --features serde,cli,strict,optimized-str,optimized-lowercase -- -D warnings` ✅
- `cargo test --no-default-features --test skipped_suites -- --nocapture` → 3 named SKIP tests + `SKIP:` lines ✅
- `cargo test --test skipped_suites` (default features, no `--nocapture`) → skip names visible in default output ✅

https://claude.ai/code/session_01Ni9jXbNFB9jpbQTw5pMQxU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ni9jXbNFB9jpbQTw5pMQxU)_