### PR TITLE
feat: track MediaWiki page id on Page (breaking → 0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Page` now exposes the MediaWiki page id via a new `id` field, populated from the `<page><id>` element when parsing a dump (a random negative id is generated for pages with a missing or invalid id, mirroring revision-id handling). `wikiwho-cli` surfaces it as a `page_id` field in its JSON output.
+
+### Changed
+
+- **Breaking:** `Page` gained a public `id` field, so struct-literal construction of `Page` must now set it; the crate version is bumped to 0.4.0 accordingly. Data serialized by earlier versions still deserializes — the field defaults to `0` when absent.
+
 ### Fixed
 
 - `wikiwho-cli --help` now advertises the page-limit flag under its actual long name `--limit` (it previously printed a non-existent `--pages`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "wikiwho"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "aho-corasick",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wikiwho"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MPL-2.0 AND MIT"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ With the default `jsonl` format, each line is one self-contained JSON object des
 
 ```json
 {
+  "page_id": 168,
   "article_title": "Anontalkpagetext",
   "namespace": 8,
   "revisions": [
@@ -69,6 +70,7 @@ With the default `jsonl` format, each line is one self-contained JSON object des
 
 `revisions` lists the page's revisions in chronological order; `all_tokens` lists every token (token ≈ word) surviving in the current revision, in reading order. The less obvious fields:
 
+- **`page_id`** — the MediaWiki page id (from the dump's `<page><id>`); `0`, or a random negative number for pages whose id was missing/invalid.
 - **`editor`** — user id as a string, or `"0|<username>"` for anonymous/IP edits.
 - **`spam_ids`** — revision ids flagged as spam/vandalism and excluded from attribution.
 - **`o_rev_id`** / **`editor`** (on a token) — the revision and author that *first introduced* it; this is the authorship attribution.

--- a/src/bin/wikiwho-cli.rs
+++ b/src/bin/wikiwho-cli.rs
@@ -723,6 +723,7 @@ fn write_page_result(
 /// PageAnalysis)>` cart, which keeps the borrowed data alive.
 #[derive(serde::Serialize, yoke::Yokeable)]
 struct PageOutput<'a> {
+    page_id: i32,
     article_title: &'a str,
     namespace: i32,
     revisions: Vec<RevisionOutput<'a>>,
@@ -791,6 +792,7 @@ fn build_page_output<'a>(page: &'a Page, analysis: &'a PageAnalysis) -> PageOutp
         .collect();
 
     PageOutput {
+        page_id: page.id,
         article_title: &page.title,
         namespace: page.namespace,
         revisions,

--- a/src/dump_parser/mod.rs
+++ b/src/dump_parser/mod.rs
@@ -697,6 +697,7 @@ impl<R: BufRead> DumpParser<R> {
         let span = tracing::span!(tracing::Level::DEBUG, "parse_page", self=?self, title=tracing::field::Empty);
 
         let mut page = Page {
+            id: 0,
             title: CompactString::default(),
             namespace: 0,
             revisions: Vec::new(),
@@ -783,7 +784,19 @@ impl<R: BufRead> DumpParser<R> {
                             }
                             span.record("title", page.title.as_str());
                         }
-                        [MediaWiki, Page, Id] => { /* ignore page id */ }
+                        [MediaWiki, Page, Id] => {
+                            page.id = if let Ok(id) = text.parse() {
+                                id
+                            } else {
+                                tracing::warn!(
+                                    message = "Found invalid page id, generating a random id",
+                                    id = text.as_ref(),
+                                    position = self.xml_parser.buffer_position()
+                                );
+                                // always use negative ids for invalid ids
+                                rand::rng().random_range(i32::MIN..-100)
+                            };
+                        }
                         [MediaWiki, Page, Ns] => {
                             let ns = if let Ok(id) = text.parse() {
                                 id

--- a/src/dump_parser/types.rs
+++ b/src/dump_parser/types.rs
@@ -88,6 +88,13 @@ pub struct Revision {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Page {
+    /// The MediaWiki page id (the `<page><id>` element in a dump).
+    ///
+    /// Defaults to `0` when deserializing data that predates this field (it was added in
+    /// 0.4.0). For pages parsed from a dump with a missing or invalid id, a random negative
+    /// id is generated so distinct pages stay distinguishable.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub id: i32,
     pub title: CompactString,
     pub namespace: i32,
     pub revisions: Vec<Revision>,

--- a/tests/algorithm_exact_tests.rs
+++ b/tests/algorithm_exact_tests.rs
@@ -205,6 +205,7 @@ fn test_case_1() {
     // found by proptest
     Python::attach(|py| {
         let page = Page {
+            id: 0,
             title: "Test".into(),
             namespace: 0,
             revisions: vec![
@@ -256,6 +257,7 @@ fn test_case_1() {
 fn test_case_2() {
     // found by proptest
     let page = Page {
+        id: 0,
         title: "Test".into(),
         namespace: 0,
         revisions: vec![

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -877,6 +877,7 @@ pub mod proptest_support {
                 (revisions in correct_revision_vec(has_hash, text_strategy.clone(), max_revisions))
         -> Page {
             Page {
+                id: 0, /* ignored in algorithm */
                 title: "Pagetitle".into(), /* ignored in algorithm */
                 namespace: 0, /* ignored in algorithm */
                 revisions

--- a/tests/fixtures/exact-regressions/Anontalkpagetext_shortened.json
+++ b/tests/fixtures/exact-regressions/Anontalkpagetext_shortened.json
@@ -1,4 +1,5 @@
 {
+    "id": 168,
     "title": "Anontalkpagetext",
     "namespace": 0,
     "revisions": [


### PR DESCRIPTION
Part of #15 — re-adding the WIP that #14 dropped.

#14 reverted three unfinished changes that `d0ef62c` had bundled into the CI commit, restoring the v0.3.1 public API. This PR re-adds the **page-id tracking** as a reviewed change. (The `-c/--compression-level` flag is a separate PR; the third item — the `serialize_editor` username-only hack — was already finished by #14 and needs nothing.)

## What changed
- `Page` gains a public `id: i32`, parsed from the dump's `<page><id>` element. Missing/invalid ids fall back to a random negative id, mirroring the existing revision-id handling.
- `wikiwho-cli` emits it as a `page_id` field (first key) in JSON output.
- The field is `#[serde(default)]` so data serialized by earlier versions still deserializes (defaults to `0`). **This is new vs. the original WIP — flagging for review.**

## SemVer
Adding a public field to `Page` is a breaking API change, so `version` is bumped **0.3.4 → 0.4.0** (the `semver` CI gate requires it). CHANGELOG and the README output-format docs are updated to match.

## Validation
`cargo fmt --check`, `clippy --all-features --all-targets -D warnings`, `cargo test --lib`, and doc tests all pass locally. End-to-end: running the CLI on the committed `Anontalkpagetext` XML fixture (page `<id>168`) now emits `"page_id":168`. The Python-parity exact tests (`--features python-diff`) run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5NRUybqBiNVdnfqyarK9L

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5NRUybqBiNVdnfqyarK9L)_