### PR TITLE
feat(cli): add -c/--compression-level for output encoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `wikiwho-cli` gained a `-c`/`--compression-level N` option to set the compression level of the output encoder (bzip2 1–9, gzip 0–9, zstd 0–22); it is ignored when the output is uncompressed, and the previous codec defaults are used when the flag is omitted.
+
 ### Fixed
 
 - `wikiwho-cli --help` now advertises the page-limit flag under its actual long name `--limit` (it previously printed a non-existent `--pages`).

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cargo install wikiwho --features cli
 wikiwho-cli dewiktionary-latest-pages-meta-history.xml.bz2 --namespace 0 -o out.jsonl
 ```
 
-The input is a standard `*-pages-meta-history*` export from [Wikimedia dumps](https://dumps.wikimedia.org/); omit the path (or pass `-`) to read from stdin. Besides `--namespace` and `-o`, the common flags are `-f/--format` (`jsonl` (default), `json`, or `raw`), `-j/--jobs`, `-N/--limit` (first N pages) and `-q/--quiet` — run `wikiwho-cli --help` for the full list.
+The input is a standard `*-pages-meta-history*` export from [Wikimedia dumps](https://dumps.wikimedia.org/); omit the path (or pass `-`) to read from stdin. Besides `--namespace` and `-o`, the common flags are `-f/--format` (`jsonl` (default), `json`, or `raw`), `-c/--compression-level` (output encoder level, ignored for uncompressed output), `-j/--jobs`, `-N/--limit` (first N pages) and `-q/--quiet` — run `wikiwho-cli --help` for the full list.
 
 Once you have `out.jsonl`, drop it onto [`tools/wikiwho-viewer.html`](tools/wikiwho-viewer.html), a self-contained drag-and-drop browser viewer that colours each token by its author and age (no server or build step).
 

--- a/src/bin/wikiwho-cli.rs
+++ b/src/bin/wikiwho-cli.rs
@@ -44,14 +44,15 @@ Arguments:
                           Compression auto-detected from extension (.bz2, .zst, .gz)
 
 Options:
-  -o, --output PATH       Output file (omit or \"-\" for stdout)
-                          Compression auto-detected from extension (.bz2, .zst, .gz)
-  -f, --format FORMAT     Output format: jsonl (default), json, raw
-  -j, --jobs N            Number of worker threads (default: number of CPUs)
-  -n, --namespace NS      Only process pages in this namespace (repeatable)
-  -N, --limit N           Only process the first N pages
-  -q, --quiet             Suppress progress messages on stderr
-  -h, --help              Show this help message"
+  -o, --output PATH         Output file (omit or \"-\" for stdout)
+                            Compression auto-detected from extension (.bz2, .zst, .gz)
+  -f, --format FORMAT       Output format: jsonl (default), json, raw
+  -c, --compression-level N Compression level for output encoder, ignored if uncompressed
+  -j, --jobs N              Number of worker threads (default: number of CPUs)
+  -n, --namespace NS        Only process pages in this namespace (repeatable)
+  -N, --limit N             Only process the first N pages
+  -q, --quiet               Suppress progress messages on stderr
+  -h, --help                Show this help message"
     );
 }
 
@@ -72,6 +73,12 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         "output",
         "Output file (\"-\" or omit for stdout)",
         "PATH",
+    );
+    opts.optopt(
+        "c",
+        "compression-level",
+        "Compression level for output encoder",
+        "LEVEL",
     );
     opts.optopt(
         "f",
@@ -120,6 +127,16 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             .unwrap_or(1),
     };
 
+    let compression_level: Option<i32> = if let Some(level_str) = matches.opt_str("c") {
+        Some(
+            level_str
+                .parse::<i32>()
+                .map_err(|e| format!("invalid -c value: {e}"))?,
+        )
+    } else {
+        None
+    };
+
     let namespace_filter: Vec<i32> = matches
         .opt_strs("n")
         .iter()
@@ -161,18 +178,46 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             let file = std::fs::File::create(path)
                 .map_err(|e| format!("cannot create output '{path}': {e}"))?;
             if path.ends_with(".bz2") {
+                let compression = if let Some(level) = compression_level {
+                    u32::try_from(level)
+                        .ok()
+                        .and_then(bzip2::Compression::try_new)
+                        .ok_or_else(|| format!("invalid compression level for bzip2: {level}"))?
+                } else {
+                    bzip2::Compression::default()
+                };
+
                 Box::new(BufWriter::new(bzip2::write::BzEncoder::new(
                     file,
-                    bzip2::Compression::default(),
+                    compression,
                 )))
             } else if path.ends_with(".zst") || path.ends_with(".zstd") {
+                if matches!(compression_level, Some(level) if !(0..=22).contains(&level)) {
+                    return Err(format!(
+                        "invalid compression level for zstd: {}",
+                        compression_level.unwrap()
+                    )
+                    .into());
+                }
+
                 Box::new(BufWriter::new(
-                    zstd::Encoder::new(file, 3).map_err(|e| format!("zstd init: {e}"))?,
+                    zstd::Encoder::new(file, compression_level.unwrap_or(3))
+                        .map_err(|e| format!("zstd init: {e}"))?,
                 ))
             } else if path.ends_with(".gz") {
+                let compression = if let Some(level) = compression_level {
+                    u32::try_from(level)
+                        .ok()
+                        .filter(|&level| level <= 9)
+                        .map(flate2::Compression::new)
+                        .ok_or_else(|| format!("invalid compression level for gz: {level}"))?
+                } else {
+                    flate2::Compression::default()
+                };
+
                 Box::new(BufWriter::new(flate2::write::GzEncoder::new(
                     file,
-                    flate2::Compression::default(),
+                    compression,
                 )))
             } else {
                 Box::new(BufWriter::new(file))


### PR DESCRIPTION
Part of #15 — re-adding the WIP that #14 dropped.

Re-adds the **`-c`/`--compression-level`** CLI option that `d0ef62c` had bundled in as unfinished WIP and #14 reverted. (Page-id tracking is a separate PR.)

## What changed
`wikiwho-cli -c/--compression-level N` sets the output encoder's level, validated per codec with clean error messages:
- bzip2: `1..=9` (via `Compression::try_new`)
- gzip: `0..=9`
- zstd: `0..=22`

When the flag is omitted, each codec keeps its previous default; it is ignored for uncompressed output. Help text, README and CHANGELOG are updated.

Two small **deliberate improvements over the original WIP** (flagging for review):
- preserve the current zstd default of **3** when `-c` is absent (the WIP would have changed it to `0`);
- reject gzip levels `>9` with a clear error instead of passing them through to the encoder.

## SemVer
CLI-only and additive — the binary lives in `[[bin]]`, not the library API — so no version bump.

## Validation
`cargo fmt --check` and `clippy --all-features --all-targets -D warnings` pass. End-to-end on the committed XML fixture: bzip2/gzip/zstd all round-trip at custom levels (verified by decompressing the output), uncompressed output ignores `-c`, and every out-of-range/invalid value (`-c 0` for bzip2, `99`, negative, non-numeric) errors with exit code 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5NRUybqBiNVdnfqyarK9L

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5NRUybqBiNVdnfqyarK9L)_